### PR TITLE
Add social senses, a pheromone layer, obstacles, richer objectives and inspection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ random noise; watch the survival percentage climb.
 
 ## How it works
 
-A generation runs for a fixed number of timesteps. At the end, a **survival
-criterion** decides who reproduces — by default, "be in the left fifth of the
-world". Survivors are cloned with mutation until the population is full again,
-the grid is cleared, and the next generation starts.
+A generation runs for a fixed number of timesteps. At the end, an **objective**
+decides who reproduces. Survivors are cloned with mutation until the population
+is full again, the grid is cleared, and the next generation starts.
 
 Each organism has a **genome**: a fixed-length tuple of genes, where every gene
 is one connection.
@@ -31,12 +30,102 @@ onto a sense it never used, or hand an action over to a different part of its
 brain. Inner neurons keep their value between timesteps, so recurrence — and
 therefore memory — is something evolution can find on its own.
 
-Every organism's wiring can be read back as text, which is how you work out
-what a behaviour actually *is*:
+Every organism's wiring can be read back as text, or drawn with `--draw-brain`:
 
 ```
 border_distance --(-2.13)--> move_x
 inner_2 --(+1.44)--> move_forward
+```
+
+## What a creature can sense
+
+All readings are held in `[-1, 1]` so no single sense dominates a brain.
+
+| group | senses |
+| --- | --- |
+| where am I | `x_position`, `y_position`, `border_distance` |
+| what is around me | `population_density`, `neighbours_east`, `neighbours_north`, `nearest_neighbour`, `blocked_forward`, `blocked_left`, `blocked_right` |
+| what can I smell | `pheromone_here`, `pheromone_east`, `pheromone_north` |
+| what was I doing | `last_move_x`, `last_move_y`, `age`, `random`, `bias` |
+
+The `neighbours_*` pair is signed and directional — `+1` means every neighbour
+in range lies that way. That is what makes following, flocking and fleeing
+reachable at all; `population_density` alone only says "it is crowded here".
+
+## What a creature can do
+
+`move_x`, `move_y`, `move_forward`, `move_left`, `move_random`, `stay`, and
+`emit_pheromone`. The action neurons compete rather than take turns: their
+levels sum into an urge per axis, resolved probabilistically into one step.
+
+`emit_pheromone` is the only way one creature can change what another
+perceives. Scent decays every timestep, so trails fade unless they are
+maintained.
+
+## Objectives
+
+The objective is the entire selection pressure, and swapping it is the main
+dial for changing what evolves.
+
+| objective | rule |
+| --- | --- |
+| `left`, `right`, `centre`, `corners` | be inside the region when the generation ends |
+| `stay`, `stay-centre` | spend at least half the generation inside the region |
+| `there-and-back` | touch the east band, then finish in the west one |
+| `top-to-bottom` | touch the north band, then finish in the south one |
+| `hazard` | survive a roaming circle that kills whatever it touches |
+
+`stay` is much harsher than `left`: arriving late is worthless. The two-phase
+objectives are the first that cannot be solved by a fixed heading — a creature
+has to change its mind partway through, which means routing `age` or a
+recurrent inner neuron into its movement.
+
+## Obstacles
+
+`--barriers none|wall|slalom|pillars|funnel`. Barriers are solid cells that
+block movement and register on the `blocked_*` senses, which turns "head west"
+from a complete solution into one that strands a creature in a dead end.
+
+## Things to try
+
+```bash
+uv run python execute.py --objective stay --barriers slalom
+uv run python execute.py --compare left,stay,corners,hazard   # race them, headless
+uv run python execute.py --objective hazard --watch 1         # watch things die
+uv run python execute.py --watch 0                            # numbers only, fastest
+uv run python execute.py --seed 42                            # repeatable run
+```
+
+Keep a creature you like, and start a later run from it:
+
+```bash
+uv run python execute.py --objective corners --save-genome good_creature.json
+uv run python execute.py --load-genome good_creature.json --draw-brain
+```
+
+Genomes are saved as JSON keyed by sense and action *names*, so a file stays
+valid after new capabilities are added.
+
+## Extending it
+
+Each of these is a single edit, and nothing else needs to change:
+
+- **a new sense** — a member of `Sensor` plus its function in `capability_utils.py`
+- **a new action** — a member of `Action`, plus how it resolves in `Organism.act`
+- **a new objective** — a subclass of `Objective` in `objectives.py`; the
+  animation draws its zones without being taught about them
+- **a new obstacle layout** — a function plus an entry in `barriers.LAYOUTS`
+
+`Settings` is frozen, so vary it with `dataclasses.replace` rather than by
+assigning to module globals:
+
+```python
+from dataclasses import replace
+from organism import World
+from settings import Settings
+
+config = replace(Settings(), point_mutation_rate=0.08, pheromone_decay=0.99)
+world = World(config=config, objective="there-and-back")
 ```
 
 ## Files
@@ -46,47 +135,33 @@ inner_2 --(+1.44)--> move_forward
 | `settings.py` | `Settings`, a frozen dataclass holding every tunable number |
 | `capability_utils.py` | the `Sensor` and `Action` enums — what a creature can perceive and do |
 | `brain_utils.py` | genes, mutation, and the network a genome builds |
-| `organism.py` | `Organism`, `World`, the generational cycle, and the survival criteria |
-| `execute.py` | the runner and the live animation |
+| `organism.py` | `Organism`, `World`, the grid layers, and the generational cycle |
+| `objectives.py` | what it takes to reproduce |
+| `barriers.py` | obstacle layouts |
+| `inspect_utils.py` | saving, loading and drawing creatures |
+| `execute.py` | the runner, the live animation and the comparison mode |
 | `test_simulation.py` | invariant checks — run `uv run pytest` |
 | `sandbox.ipynb` | design notes and a scratchpad for poking at individual creatures |
-
-## Knobs worth turning
-
-```bash
-uv run python execute.py --criterion corners   # left, right, centre, corners
-uv run python execute.py --watch 0             # skip the animation, just print numbers
-uv run python execute.py --watch 5             # animate every 5th generation
-uv run python execute.py --seed 42             # repeatable run
-```
-
-The survival criterion is the whole selection pressure. Adding one is a
-four-line function at the bottom of `organism.py` plus an entry in `CRITERIA`;
-the animation works out how to shade the new zone by itself.
-
-Adding a sense or an action is a single enum member in `capability_utils.py`
-plus its function — no other file needs to change, and evolution starts using
-it on the next run.
-
-`Settings` is frozen, so vary it with `dataclasses.replace` rather than by
-assigning to module globals:
-
-```python
-from dataclasses import replace
-from organism import CRITERIA, World
-from settings import Settings
-
-config = replace(Settings(), point_mutation_rate=0.08, n_organisms=500)
-world = World(config=config, criterion=CRITERIA["corners"])
-```
 
 ## Development
 
 ```bash
 uv sync                 # create the environment
-uv run pytest           # 27 invariant checks
+uv run pytest           # 59 invariant checks
 uv run ruff check .     # lint
 uv run ruff format .    # format
 ```
 
 `uv.lock` is committed, so `uv sync` reproduces the exact dependency set.
+
+## Known limits
+
+Reproduction is asexual — mutation is the only source of variation, with no
+crossover between survivors.
+
+Selection is all-or-nothing: an objective either passes a creature or does not,
+with no partial credit. Objectives that almost nobody can satisfy early on
+therefore have no gradient to climb, and the population reseeds from random
+genomes whenever a generation produces zero survivors. Conjunctive goals need
+their two halves chosen so that some creatures get there by luck in the first
+few generations.

--- a/barriers.py
+++ b/barriers.py
@@ -1,0 +1,108 @@
+"""
+Obstacle layouts.
+
+A layout is a function that returns a boolean grid the same shape as the world:
+True means the cell is solid and nothing can enter it. Barriers are what turn
+"head west" from a complete solution into one that strands a creature in a
+dead end, so they are the cheapest way to make an objective genuinely hard.
+
+Adding a layout is one function plus an entry in `LAYOUTS`. Everything else --
+placement, movement, the `blocked_forward` sense, the animation -- picks it up
+automatically.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import numpy.typing as npt
+
+type Layout = Callable[[int, int], npt.NDArray[np.bool_]]
+"""Given (width, height), return the grid of solid cells."""
+
+
+def none(width: int, height: int) -> npt.NDArray[np.bool_]:
+    """An empty box."""
+    return np.zeros((width, height), dtype=bool)
+
+
+def wall(width: int, height: int) -> npt.NDArray[np.bool_]:
+    """A single vertical wall with one gap in the middle of it."""
+    grid = np.zeros((width, height), dtype=bool)
+    x = width // 2
+    gap = height // 10
+    grid[x - 1 : x + 1, :] = True
+    grid[x - 1 : x + 1, height // 2 - gap : height // 2 + gap] = False
+    return grid
+
+
+def slalom(width: int, height: int) -> npt.NDArray[np.bool_]:
+    """
+    Three walls with gaps at alternating ends.
+
+    A straight dash west fails here: a creature has to move along a wall to
+    find the opening, which is exactly what `blocked_forward` is good for.
+    """
+    grid = np.zeros((width, height), dtype=bool)
+    gap = height // 4
+    for i, x in enumerate((width // 4, width // 2, 3 * width // 4)):
+        grid[x - 1 : x + 1, :] = True
+        if i % 2 == 0:
+            grid[x - 1 : x + 1, :gap] = False
+        else:
+            grid[x - 1 : x + 1, height - gap :] = False
+    return grid
+
+
+def pillars(width: int, height: int) -> npt.NDArray[np.bool_]:
+    """A regular field of square blocks to weave between."""
+    grid = np.zeros((width, height), dtype=bool)
+    spacing = max(8, width // 8)
+    size = max(2, spacing // 3)
+    for x in range(spacing, width - spacing + 1, spacing):
+        for y in range(spacing, height - spacing + 1, spacing):
+            grid[x : x + size, y : y + size] = True
+    return grid
+
+
+def funnel(width: int, height: int) -> npt.NDArray[np.bool_]:
+    """
+    Two diagonal walls narrowing to a small opening on the west side.
+
+    Crowding matters here -- the gap only fits a few creatures at a time, so
+    the neighbour senses start to earn their keep.
+    """
+    grid = np.zeros((width, height), dtype=bool)
+    mouth = max(2, height // 20)
+    start, end = width // 3, 2 * width // 3
+    for x in range(start, end):
+        # Wide open at the eastern end, narrowing to `mouth` at the west.
+        along = (x - start) / max(1, end - 1 - start)
+        half_gap = int(mouth + along * (height / 2 - mouth))
+        grid[x, : height // 2 - half_gap] = True
+        grid[x, height // 2 + half_gap :] = True
+    return grid
+
+
+LAYOUTS: Final[dict[str, Layout]] = {
+    "none": none,
+    "wall": wall,
+    "slalom": slalom,
+    "pillars": pillars,
+    "funnel": funnel,
+}
+
+
+def build(name: str, width: int, height: int) -> npt.NDArray[np.bool_]:
+    """Build a named layout, raising a helpful error if the name is unknown."""
+    try:
+        layout = LAYOUTS[name]
+    except KeyError:
+        known = ", ".join(sorted(LAYOUTS))
+        raise ValueError(f"unknown barrier layout {name!r}; try one of: {known}") from None
+    return layout(width, height)

--- a/capability_utils.py
+++ b/capability_utils.py
@@ -8,6 +8,14 @@ file needs to change.
 
 Sensor functions take (organism, world) and return a float in [-1, 1], so that
 no single sensor dominates the weighted sums inside a brain.
+
+The senses fall into four groups:
+
+- where am I           position, distance to the walls
+- what is around me    neighbours and obstacles, and which *direction* they lie in
+- what can I smell     the pheromone layer, which is the only channel one
+                       organism has for affecting what another perceives
+- what was I doing     previous movement, age, noise, a constant
 """
 
 from __future__ import annotations
@@ -21,9 +29,6 @@ if TYPE_CHECKING:
 
     from organism import Organism, World
 
-# Radius, in cells, of the neighbourhood an organism can feel around itself.
-DENSITY_RADIUS: Final = 4
-
 
 class Sensor(IntEnum):
     """Everything an organism can perceive. Values index into sensor readings."""
@@ -32,12 +37,20 @@ class Sensor(IntEnum):
     Y_POSITION = 1
     BORDER_DISTANCE = 2
     POPULATION_DENSITY = 3
-    BLOCKED_FORWARD = 4
-    LAST_MOVE_X = 5
-    LAST_MOVE_Y = 6
-    AGE = 7
-    RANDOM = 8
-    BIAS = 9
+    NEIGHBOURS_EAST = 4
+    NEIGHBOURS_NORTH = 5
+    NEAREST_NEIGHBOUR = 6
+    BLOCKED_FORWARD = 7
+    BLOCKED_LEFT = 8
+    BLOCKED_RIGHT = 9
+    PHEROMONE_HERE = 10
+    PHEROMONE_EAST = 11
+    PHEROMONE_NORTH = 12
+    LAST_MOVE_X = 13
+    LAST_MOVE_Y = 14
+    AGE = 15
+    RANDOM = 16
+    BIAS = 17
 
     def __str__(self) -> str:
         return self.name.lower()
@@ -60,11 +73,17 @@ class Action(IntEnum):
     MOVE_FORWARD = 2
     """Keep going the way you last went."""
 
-    MOVE_RANDOM = 3
+    MOVE_LEFT = 3
+    """Turn ninety degrees left of the last heading and go."""
+
+    MOVE_RANDOM = 4
     """Take an arbitrary step."""
 
-    STAY = 4
+    STAY = 5
     """Suppress movement."""
+
+    EMIT_PHEROMONE = 6
+    """Lay scent on the current cell, for others (and yourself) to smell later."""
 
     def __str__(self) -> str:
         return self.name.lower()
@@ -74,7 +93,7 @@ type SensorFn = Callable[[Organism, World], float]
 
 
 # ----------------------------------------------------------------------------
-# Sensor implementations
+# Where am I
 # ----------------------------------------------------------------------------
 
 
@@ -95,17 +114,85 @@ def sense_border_distance(org: Organism, world: World) -> float:
     return min(to_wall / half_span, 1.0)
 
 
+# ----------------------------------------------------------------------------
+# What is around me
+# ----------------------------------------------------------------------------
+
+
 def sense_population_density(org: Organism, world: World) -> float:
-    """Fraction of nearby cells that hold another organism."""
-    return world.population_density(org.x, org.y, DENSITY_RADIUS)
+    """How crowded it is nearby, with no indication of direction."""
+    return world.population_density(org.x, org.y, world.config.sense_radius)
+
+
+def sense_neighbours_east(org: Organism, world: World) -> float:
+    """
+    Which side holds more neighbours: +1 all east, -1 all west, 0 balanced.
+
+    Paired with `neighbours_north`, this is what makes following, flocking and
+    fleeing reachable at all -- density alone only says "it is crowded here".
+    """
+    return world.neighbour_gradient(org.x, org.y, world.config.sense_radius)[0]
+
+
+def sense_neighbours_north(org: Organism, world: World) -> float:
+    """Which side holds more neighbours: +1 all north, -1 all south, 0 balanced."""
+    return world.neighbour_gradient(org.x, org.y, world.config.sense_radius)[1]
+
+
+def sense_nearest_neighbour(org: Organism, world: World) -> float:
+    """1 when another organism is adjacent, 0 when none is within sensing range."""
+    return world.nearest_neighbour(org.x, org.y, world.config.sense_radius)
 
 
 def sense_blocked_forward(org: Organism, world: World) -> float:
-    """1 if the cell the organism last moved toward is now a wall or another organism."""
-    if org.last_dx == 0 and org.last_dy == 0:
+    """1 if the cell the organism last moved toward is a wall, barrier or organism."""
+    return _blocked(org, world, quarter_turns=0)
+
+
+def sense_blocked_left(org: Organism, world: World) -> float:
+    """1 if the cell ninety degrees left of the current heading is blocked."""
+    return _blocked(org, world, quarter_turns=1)
+
+
+def sense_blocked_right(org: Organism, world: World) -> float:
+    """1 if the cell ninety degrees right of the current heading is blocked."""
+    return _blocked(org, world, quarter_turns=-1)
+
+
+def _blocked(org: Organism, world: World, quarter_turns: int) -> float:
+    """Whether the cell that many quarter-turns left of the heading is unavailable."""
+    dx, dy = org.last_dx, org.last_dy
+    if dx == 0 and dy == 0:
         return 0.0
-    ahead_x, ahead_y = org.x + org.last_dx, org.y + org.last_dy
-    return 0.0 if world.can_move_to(ahead_x, ahead_y) else 1.0
+    # Rotating a quarter turn to the left maps (dx, dy) -> (-dy, dx).
+    for _ in range(quarter_turns % 4):
+        dx, dy = -dy, dx
+    return 0.0 if world.can_move_to(org.x + dx, org.y + dy) else 1.0
+
+
+# ----------------------------------------------------------------------------
+# What can I smell
+# ----------------------------------------------------------------------------
+
+
+def sense_pheromone_here(org: Organism, world: World) -> float:
+    """Strength of the scent on the organism's own cell."""
+    return world.pheromone_at(org.x, org.y)
+
+
+def sense_pheromone_east(org: Organism, world: World) -> float:
+    """Which side smells stronger: +1 east, -1 west, 0 balanced or unscented."""
+    return world.pheromone_gradient(org.x, org.y, world.config.sense_radius)[0]
+
+
+def sense_pheromone_north(org: Organism, world: World) -> float:
+    """Which side smells stronger: +1 north, -1 south, 0 balanced or unscented."""
+    return world.pheromone_gradient(org.x, org.y, world.config.sense_radius)[1]
+
+
+# ----------------------------------------------------------------------------
+# What was I doing
+# ----------------------------------------------------------------------------
 
 
 def sense_last_move_x(org: Organism, world: World) -> float:
@@ -138,7 +225,15 @@ SENSOR_FUNCTIONS: Final[dict[Sensor, SensorFn]] = {
     Sensor.Y_POSITION: sense_y_position,
     Sensor.BORDER_DISTANCE: sense_border_distance,
     Sensor.POPULATION_DENSITY: sense_population_density,
+    Sensor.NEIGHBOURS_EAST: sense_neighbours_east,
+    Sensor.NEIGHBOURS_NORTH: sense_neighbours_north,
+    Sensor.NEAREST_NEIGHBOUR: sense_nearest_neighbour,
     Sensor.BLOCKED_FORWARD: sense_blocked_forward,
+    Sensor.BLOCKED_LEFT: sense_blocked_left,
+    Sensor.BLOCKED_RIGHT: sense_blocked_right,
+    Sensor.PHEROMONE_HERE: sense_pheromone_here,
+    Sensor.PHEROMONE_EAST: sense_pheromone_east,
+    Sensor.PHEROMONE_NORTH: sense_pheromone_north,
     Sensor.LAST_MOVE_X: sense_last_move_x,
     Sensor.LAST_MOVE_Y: sense_last_move_y,
     Sensor.AGE: sense_age,

--- a/execute.py
+++ b/execute.py
@@ -1,9 +1,11 @@
 """
 Run the simulation.
 
-    uv run python execute.py                      # survive by reaching the west wall
-    uv run python execute.py --criterion corners  # a different selection pressure
-    uv run python execute.py --watch 0            # no animation, just the numbers
+    uv run python execute.py                              # reach the west wall
+    uv run python execute.py --objective stay             # and hold position there
+    uv run python execute.py --barriers slalom            # make it work for it
+    uv run python execute.py --compare left,stay,corners  # race objectives, headless
+    uv run python execute.py --watch 0                    # no animation, just numbers
 
 Generation 0 is random noise. Watch the survival percentage climb.
 """
@@ -14,11 +16,15 @@ import argparse
 import random
 import time
 from dataclasses import replace
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
 
-from organism import CRITERIA, World
+import barriers
+import inspect_utils
+from objectives import OBJECTIVES
+from organism import Organism, World
 from settings import Settings
 
 if TYPE_CHECKING:
@@ -33,10 +39,16 @@ def parse_args() -> argparse.Namespace:
     )
     defaults = Settings()
     parser.add_argument(
-        "--criterion",
-        choices=sorted(CRITERIA),
+        "--objective",
+        choices=list(OBJECTIVES),
         default="left",
-        help="which survival criterion selects who reproduces",
+        help="what a creature has to do to earn the right to reproduce",
+    )
+    parser.add_argument(
+        "--barriers",
+        choices=sorted(barriers.LAYOUTS),
+        default=defaults.barrier_layout,
+        help="obstacle layout built into the world",
     )
     parser.add_argument("--generations", type=int, default=defaults.n_generations)
     parser.add_argument("--population", type=int, default=defaults.n_organisms)
@@ -59,42 +71,114 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="seed the random number generators for a repeatable run",
     )
+    parser.add_argument(
+        "--compare",
+        metavar="A,B,C",
+        default=None,
+        help="run several objectives headless and plot their survival curves together",
+    )
+    parser.add_argument(
+        "--save-genome",
+        metavar="PATH",
+        default=None,
+        help="write a final creature's genome to a JSON file",
+    )
+    parser.add_argument(
+        "--load-genome",
+        metavar="PATH",
+        default=None,
+        help="seed the whole starting population from a saved genome",
+    )
+    parser.add_argument(
+        "--draw-brain",
+        action="store_true",
+        help="show a wiring diagram of one final creature",
+    )
     return parser.parse_args()
 
 
-class Animator:
-    """Live scatter plot of the population, with the survival zone shaded."""
+def build_config(args: argparse.Namespace) -> Settings:
+    return replace(
+        Settings(),
+        n_organisms=args.population,
+        steps_per_generation=args.steps,
+        n_generations=args.generations,
+        barrier_layout=args.barriers,
+    )
 
-    def __init__(self, world: World, criterion_name: str) -> None:
+
+class Animator:
+    """Live view of the population, its obstacles, its scent trails and its goal."""
+
+    def __init__(self, world: World, title: str) -> None:
         import matplotlib.pyplot as plt
 
         self.plt = plt
-        self.criterion_name = criterion_name
+        self.title = title
 
         self.figure: Figure
         self.axes: Axes
-        self.figure, self.axes = plt.subplots(figsize=(6, 6))
+        self.figure, self.axes = plt.subplots(figsize=(6.5, 6.5))
+        extent = (0, world.width, 0, world.height)
 
-        # imshow indexes [row, column] = [y, x], so transpose the [x, y] mask.
-        self.axes.imshow(
-            world.survival_zone_mask().T,
+        # imshow indexes [row, column] = [y, x], so every mask is transposed.
+        self.zone_images = []
+        for shading in world.objective.zones(world):
+            self.zone_images.append(
+                self.axes.imshow(
+                    shading.mask.T,
+                    origin="lower",
+                    cmap=shading.colour,
+                    alpha=0.3,
+                    extent=extent,
+                    vmin=0,
+                    vmax=1,
+                    zorder=0,
+                )
+            )
+
+        self.pheromone_image = self.axes.imshow(
+            world.pheromone.T,
             origin="lower",
-            cmap="Greens",
-            alpha=0.25,
-            extent=(0, world.width, 0, world.height),
+            cmap="BuPu",
+            alpha=0.55,
+            extent=extent,
+            vmin=0,
+            vmax=1,
+            zorder=1,
         )
-        self.scatter = self.axes.scatter([], [], s=6)
+        # Solid cells are drawn opaque, empty ones fully transparent.
+        self.axes.imshow(
+            np.ma.masked_where(~world.barriers.T, world.barriers.T),
+            origin="lower",
+            cmap="Greys",
+            alpha=0.85,
+            extent=extent,
+            vmin=0,
+            vmax=1,
+            zorder=2,
+        )
+
+        self.scatter = self.axes.scatter([], [], s=7, zorder=3)
         self.axes.set_xlim(0, world.width)
         self.axes.set_ylim(0, world.height)
+        self.dynamic_zones = world.objective.dynamic
 
         plt.ion()
         plt.show(block=False)
 
     def draw(self, world: World, step: int) -> None:
         xs, ys = world.positions()
-        self.scatter.set_offsets(np.column_stack((xs, ys)))
+        self.scatter.set_offsets(np.column_stack((xs, ys)) if len(xs) else np.empty((0, 2)))
+        self.pheromone_image.set_data(np.clip(world.pheromone.T, 0, 1))
+
+        if self.dynamic_zones:
+            shadings = world.objective.zones(world)
+            for image, shading in zip(self.zone_images, shadings, strict=False):
+                image.set_data(shading.mask.T)
+
         self.axes.set_title(
-            f"{self.criterion_name} criterion | generation {world.generation} | step {step}"
+            f"{self.title} | generation {world.generation} | step {step} | alive {len(xs)}"
         )
         self.figure.canvas.draw_idle()
         self.plt.pause(0.001)
@@ -104,26 +188,28 @@ class Animator:
         self.plt.close(self.figure)
 
 
-def main() -> None:
-    args = parse_args()
+def seed_population(world: World, path: str) -> None:
+    """Replace every starting genome with one loaded from disk."""
+    genome = inspect_utils.load_genome(path)
+    world.organisms = [Organism(world.config, genome=genome) for _ in range(world.n_organisms)]
+    world.reset_grid(world.organisms)
+    print(f"seeded {world.n_organisms} organisms from {path}")
 
-    if args.seed is not None:
-        random.seed(args.seed)
-        np.random.seed(args.seed)
 
-    config = replace(
-        Settings(),
-        n_organisms=args.population,
-        steps_per_generation=args.steps,
-        n_generations=args.generations,
-    )
-    world = World(config=config, criterion=CRITERIA[args.criterion])
+def run(args: argparse.Namespace) -> World:
+    """Run one objective, animating as configured, and return the finished world."""
+    config = build_config(args)
+    world = World(config=config, objective=args.objective)
 
-    animator = Animator(world, args.criterion) if args.watch else None
+    if args.load_genome:
+        seed_population(world, args.load_genome)
+
+    title = args.objective if args.barriers == "none" else f"{args.objective} / {args.barriers}"
+    animator = Animator(world, title) if args.watch else None
 
     print(
-        f"{config.n_organisms} organisms, {config.steps_per_generation} steps "
-        f'per generation, "{args.criterion}" survival criterion'
+        f"{config.n_organisms} organisms, {config.steps_per_generation} steps per generation, "
+        f'"{args.objective}" objective, "{args.barriers}" barriers'
     )
 
     started = time.monotonic()
@@ -145,18 +231,71 @@ def main() -> None:
         if animator is not None:
             animator.close()
 
-    show_example_brain(world)
+    return world
 
 
-def show_example_brain(world: World) -> None:
-    """Print one organism's wiring, so the evolved behaviour can be read back."""
+def compare(args: argparse.Namespace) -> None:
+    """Race several objectives against each other and plot the result."""
+    import matplotlib.pyplot as plt
+
+    names = [name.strip() for name in args.compare.split(",") if name.strip()]
+    unknown = [name for name in names if name not in OBJECTIVES]
+    if unknown:
+        raise SystemExit(f"unknown objective(s): {', '.join(unknown)}")
+
+    config = build_config(args)
+    _, axes = plt.subplots(figsize=(8, 5))
+
+    for name in names:
+        world = World(config=config, objective=name)
+        started = time.monotonic()
+        curve = [world.run_generation() / config.n_organisms for _ in range(config.n_generations)]
+        axes.plot(curve, label=name)
+        print(f"{name:>18}   final {curve[-1]:6.1%}   {time.monotonic() - started:6.1f}s")
+
+    axes.set_xlabel("generation")
+    axes.set_ylabel("fraction surviving")
+    axes.set_ylim(0, 1)
+    axes.set_title(f"objectives compared ({args.barriers} barriers)")
+    axes.legend()
+    plt.show()
+
+
+def report(world: World, args: argparse.Namespace) -> None:
+    """Print, save and optionally draw one creature from the final generation."""
     if not world.organisms:
         return
+
     example = world.organisms[0]
     consulted = ", ".join(str(s) for s in example.brain.needed_sensors) or "none"
     print("\nwiring of one organism from the final generation:")
     print(example.brain.describe())
     print(f"\nsenses it actually consults: {consulted}")
+
+    if args.save_genome:
+        path = inspect_utils.save_genome(example.genome, world.config, Path(args.save_genome))
+        print(f"genome written to {path}")
+
+    if args.draw_brain:
+        import matplotlib.pyplot as plt
+
+        inspect_utils.draw_brain(example.brain, world.config)
+        plt.show()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+        np.random.seed(args.seed)
+
+    if args.compare:
+        compare(args)
+        return
+
+    world = run(args)
+    report(world, args)
 
 
 if __name__ == "__main__":

--- a/inspect_utils.py
+++ b/inspect_utils.py
@@ -1,0 +1,202 @@
+"""
+Tools for keeping, reloading and looking at evolved creatures.
+
+A run that produces something interesting is worth nothing if the genome
+disappears when the process exits. Genomes are saved as JSON keyed by *name*
+rather than by enum value, so a file stays readable after new senses or actions
+are added to `capability_utils`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from brain_utils import Gene, Sink, Source
+from capability_utils import Action, Sensor
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+    from brain_utils import Brain, Genome
+    from settings import Settings
+
+FORMAT_VERSION = 1
+
+
+# ----------------------------------------------------------------------------
+# Saving and loading
+# ----------------------------------------------------------------------------
+
+
+def genome_to_dict(genome: Genome, config: Settings) -> dict[str, Any]:
+    """A JSON-ready description of a genome, using names rather than indices."""
+    return {
+        "version": FORMAT_VERSION,
+        "n_inner_neurons": config.n_inner_neurons,
+        "genes": [
+            {
+                "source": _endpoint_name(gene.source_kind, gene.source_id),
+                "sink": _endpoint_name(gene.sink_kind, gene.sink_id),
+                # Written at full precision: a genome that shifts on reload is
+                # a different creature from the one that was worth keeping.
+                "weight": gene.weight,
+            }
+            for gene in genome
+        ],
+    }
+
+
+def genome_from_dict(data: dict[str, Any]) -> Genome:
+    """Rebuild a genome saved by `genome_to_dict`."""
+    version = data.get("version")
+    if version != FORMAT_VERSION:
+        raise ValueError(f"unsupported genome format {version!r}, expected {FORMAT_VERSION}")
+
+    genes = []
+    for entry in data["genes"]:
+        source_kind, source_id = _parse_endpoint(entry["source"], as_source=True)
+        sink_kind, sink_id = _parse_endpoint(entry["sink"], as_source=False)
+        genes.append(Gene(source_kind, source_id, sink_kind, sink_id, float(entry["weight"])))
+    return tuple(genes)
+
+
+def save_genome(genome: Genome, config: Settings, path: str | Path) -> Path:
+    """Write one genome to a JSON file."""
+    path = Path(path)
+    path.write_text(json.dumps(genome_to_dict(genome, config), indent=2), encoding="utf-8")
+    return path
+
+
+def load_genome(path: str | Path) -> Genome:
+    """Read a genome written by `save_genome`."""
+    return genome_from_dict(json.loads(Path(path).read_text(encoding="utf-8")))
+
+
+def _endpoint_name(kind: Source | Sink, index: int) -> str:
+    if kind is Source.SENSOR:
+        return str(Sensor(index))
+    if kind is Sink.ACTION:
+        return str(Action(index))
+    return f"inner_{index}"
+
+
+def _parse_endpoint(name: str, as_source: bool) -> tuple[Any, int]:
+    """Turn a saved endpoint name back into its (kind, id) pair."""
+    if name.startswith("inner_"):
+        kind = Source.INNER if as_source else Sink.INNER
+        return kind, int(name.removeprefix("inner_"))
+
+    if as_source:
+        return Source.SENSOR, int(Sensor[name.upper()])
+    return Sink.ACTION, int(Action[name.upper()])
+
+
+# ----------------------------------------------------------------------------
+# Drawing a brain
+# ----------------------------------------------------------------------------
+
+
+def draw_brain(brain: Brain, config: Settings, axes: Axes | None = None) -> Axes:
+    """
+    Draw a brain as a wiring diagram: senses left, inner neurons middle, actions right.
+
+    Line thickness follows the strength of a connection and colour follows its
+    sign, so the shape of a behaviour is visible at a glance in a way the text
+    listing never manages. Only the senses and inner neurons the genome
+    actually uses are drawn.
+    """
+    import matplotlib.pyplot as plt
+
+    if axes is None:
+        _, axes = plt.subplots(figsize=(9, 7))
+
+    used_inner = sorted(
+        {gene.source_id for gene in brain.genome if gene.source_kind is Source.INNER}
+        | {gene.sink_id for gene in brain.genome if gene.sink_kind is Sink.INNER}
+    )
+    used_actions = sorted({gene.sink_id for gene in brain.genome if gene.sink_kind is Sink.ACTION})
+
+    sensor_pos = _column([str(s) for s in brain.needed_sensors], x=0.0)
+    inner_pos = _column([f"inner_{i}" for i in used_inner], x=1.0)
+    action_pos = _column([str(Action(a)) for a in used_actions], x=2.0)
+
+    def locate(kind: Source | Sink, index: int, source: bool) -> tuple[float, float] | None:
+        if source and kind is Source.SENSOR:
+            return sensor_pos.get(str(Sensor(index)))
+        if not source and kind is Sink.ACTION:
+            return action_pos.get(str(Action(index)))
+        return inner_pos.get(f"inner_{index}")
+
+    strongest = max((abs(gene.weight) for gene in brain.genome), default=1.0) or 1.0
+
+    for gene in brain.genome:
+        start = locate(gene.source_kind, gene.source_id, source=True)
+        end = locate(gene.sink_kind, gene.sink_id, source=False)
+        if start is None or end is None:
+            continue
+
+        colour = "#2c7fb8" if gene.weight >= 0 else "#d95f0e"
+        width = 0.4 + 3.0 * abs(gene.weight) / strongest
+
+        if start == end:  # a self-loop: an inner neuron feeding itself
+            axes.annotate(
+                "",
+                xy=(start[0] + 0.08, start[1] + 0.02),
+                xytext=(start[0] + 0.08, start[1] - 0.02),
+                arrowprops={
+                    "arrowstyle": "->",
+                    "color": colour,
+                    "lw": width,
+                    "connectionstyle": "arc3,rad=3.0",
+                },
+            )
+            continue
+
+        axes.annotate(
+            "",
+            xy=end,
+            xytext=start,
+            arrowprops={
+                "arrowstyle": "->",
+                "color": colour,
+                "lw": width,
+                "alpha": 0.75,
+                "shrinkA": 6,
+                "shrinkB": 6,
+                "connectionstyle": "arc3,rad=0.12",
+            },
+        )
+
+    for positions, align, style in (
+        (sensor_pos, "right", {"color": "#31a354"}),
+        (inner_pos, "center", {"color": "#756bb1"}),
+        (action_pos, "left", {"color": "#e6550d"}),
+    ):
+        for label, (x, y) in positions.items():
+            axes.text(
+                x,
+                y,
+                label,
+                ha=align,
+                va="center",
+                fontsize=9,
+                bbox={"boxstyle": "round,pad=0.3", "fc": "white", "ec": style["color"]},
+            )
+
+    axes.set_xlim(-0.6, 2.6)
+    axes.set_ylim(-0.1, 1.1)
+    axes.axis("off")
+    axes.set_title("senses  →  inner neurons  →  actions")
+    return axes
+
+
+def _column(labels: list[str], x: float) -> dict[str, tuple[float, float]]:
+    """Evenly space labels down a vertical column."""
+    if not labels:
+        return {}
+    if len(labels) == 1:
+        return {labels[0]: (x, 0.5)}
+    gap = 1.0 / (len(labels) - 1)
+    return {label: (x, i * gap) for i, label in enumerate(labels)}

--- a/objectives.py
+++ b/objectives.py
@@ -1,0 +1,274 @@
+"""
+What it takes to reproduce.
+
+An objective is the entire selection pressure, and swapping it is the main dial
+for changing what evolves. The old position-only criterion could express
+"be here at the end" and nothing else; an `Objective` can also watch an
+organism throughout the generation and change the world while it runs.
+
+Three hooks, all optional except `survives`:
+
+- `begin_generation`  set up, once per generation
+- `advance`           move whatever the objective controls, once per timestep
+- `observe`           watch one organism, once per timestep -- this is how an
+                      objective accumulates history in `organism.progress`
+- `survives`          the verdict, at the end of the generation
+
+`zones` reports the regions worth drawing, so the animation illustrates any new
+objective without being taught about it.
+"""
+
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import numpy.typing as npt
+
+    from organism import Organism, World
+
+type Zone = Callable[[int, int, "World"], bool]
+"""Whether a given cell belongs to a named region of the world."""
+
+
+@dataclass(frozen=True, slots=True)
+class Shading:
+    """A region for the animation to draw."""
+
+    mask: npt.NDArray[np.bool_]
+    colour: str
+    label: str
+
+
+# ----------------------------------------------------------------------------
+# Regions
+# ----------------------------------------------------------------------------
+
+
+def left_edge(x: int, y: int, world: World) -> bool:
+    """A band along the west wall."""
+    return x < world.width * world.config.survival_zone_fraction
+
+
+def right_edge(x: int, y: int, world: World) -> bool:
+    """A band along the east wall."""
+    return x >= world.width * (1 - world.config.survival_zone_fraction)
+
+
+def centre(x: int, y: int, world: World) -> bool:
+    """A circle at the middle of the world."""
+    radius = world.width * world.config.survival_zone_fraction
+    dx = x - world.width / 2
+    dy = y - world.height / 2
+    return dx * dx + dy * dy <= radius * radius
+
+
+def top_edge(x: int, y: int, world: World) -> bool:
+    """A band along the north wall."""
+    return y >= world.height * (1 - world.config.survival_zone_fraction)
+
+
+def bottom_edge(x: int, y: int, world: World) -> bool:
+    """A band along the south wall."""
+    return y < world.height * world.config.survival_zone_fraction
+
+
+def corners(x: int, y: int, world: World) -> bool:
+    """All four corners."""
+    span = world.width * world.config.survival_zone_fraction
+    near_x = x < span or x >= world.width - span
+    near_y = y < span or y >= world.height - span
+    return near_x and near_y
+
+
+def mask_of(zone: Zone, world: World) -> npt.NDArray[np.bool_]:
+    """Evaluate a zone over every cell, so it can be drawn."""
+    return np.array(
+        [[zone(x, y, world) for y in range(world.height)] for x in range(world.width)],
+        dtype=bool,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Objectives
+# ----------------------------------------------------------------------------
+
+
+class Objective(ABC):
+    """The rule that decides who reproduces."""
+
+    name: str = "objective"
+
+    dynamic: bool = False
+    """True if `zones` changes during a generation and must be redrawn."""
+
+    # These three are deliberately optional: most objectives only need a
+    # verdict, so doing nothing is the correct default rather than an oversight.
+    def begin_generation(self, world: World) -> None:  # noqa: B027
+        """Reset any state held for a whole generation."""
+
+    def advance(self, world: World) -> None:  # noqa: B027
+        """Move whatever this objective controls. Called once per timestep."""
+
+    def observe(self, org: Organism, world: World) -> None:  # noqa: B027
+        """Watch one organism for one timestep."""
+
+    @abstractmethod
+    def survives(self, org: Organism, world: World) -> bool:
+        """Whether this organism gets to reproduce."""
+
+    def zones(self, world: World) -> list[Shading]:
+        """Regions worth drawing. Empty means the objective has nothing to show."""
+        return []
+
+
+class ReachZone(Objective):
+    """
+    Be inside a region when the generation ends.
+
+    The original rule, and still the easiest to evolve against: only the final
+    instant matters, so a creature can do anything it likes on the way.
+    """
+
+    def __init__(self, name: str, zone: Zone) -> None:
+        self.name = name
+        self.zone = zone
+
+    def survives(self, org: Organism, world: World) -> bool:
+        return self.zone(org.x, org.y, world)
+
+    def zones(self, world: World) -> list[Shading]:
+        return [Shading(mask_of(self.zone, world), "Greens", "reach by the end")]
+
+
+class StayInZone(Objective):
+    """
+    Spend most of the generation inside a region, not merely end there.
+
+    A far harsher rule than `ReachZone`: arriving late is worthless, so it
+    rewards getting there fast and then holding position against the crowd.
+    """
+
+    def __init__(self, name: str, zone: Zone, fraction: float | None = None) -> None:
+        self.name = name
+        self.zone = zone
+        self.fraction = fraction
+
+    def _required(self, world: World) -> float:
+        fraction = self.fraction if self.fraction is not None else world.config.stay_fraction
+        return fraction * world.config.steps_per_generation
+
+    def begin_generation(self, world: World) -> None:
+        for org in world.organisms:
+            org.progress["in_zone"] = 0.0
+
+    def observe(self, org: Organism, world: World) -> None:
+        if self.zone(org.x, org.y, world):
+            org.progress["in_zone"] = org.progress.get("in_zone", 0.0) + 1.0
+
+    def survives(self, org: Organism, world: World) -> bool:
+        return org.progress.get("in_zone", 0.0) >= self._required(world)
+
+    def zones(self, world: World) -> list[Shading]:
+        return [Shading(mask_of(self.zone, world), "Greens", "stay here")]
+
+
+class VisitInOrder(Objective):
+    """
+    Touch one region, then finish in another.
+
+    This is the first objective that cannot be solved by a fixed heading. A
+    creature has to change its mind partway through, which means routing the
+    `age` sense -- or a recurrent inner neuron -- into its movement.
+    """
+
+    def __init__(self, name: str, first: Zone, second: Zone) -> None:
+        self.name = name
+        self.first = first
+        self.second = second
+
+    def begin_generation(self, world: World) -> None:
+        for org in world.organisms:
+            org.progress["visited"] = 0.0
+
+    def observe(self, org: Organism, world: World) -> None:
+        if self.first(org.x, org.y, world):
+            org.progress["visited"] = 1.0
+
+    def survives(self, org: Organism, world: World) -> bool:
+        return bool(org.progress.get("visited")) and self.second(org.x, org.y, world)
+
+    def zones(self, world: World) -> list[Shading]:
+        return [
+            Shading(mask_of(self.first, world), "Blues", "visit first"),
+            Shading(mask_of(self.second, world), "Greens", "finish here"),
+        ]
+
+
+class Hazard(Objective):
+    """
+    Survive a roaming danger that kills whatever it touches.
+
+    Unlike every other objective, this one changes the world as it runs, and
+    death is immediate rather than judged at the end. Selection stops being
+    about geometry and starts being about reacting to something that moves.
+    """
+
+    def __init__(self, name: str = "hazard") -> None:
+        self.name = name
+        self.dynamic = True
+        self.x = 0.0
+        self.y = 0.0
+
+    def _place(self, world: World) -> None:
+        """Walk the hazard around a circle inscribed in the world."""
+        period = max(1, world.config.hazard_period)
+        angle = 2 * math.pi * (world.step % period) / period
+        self.x = world.width / 2 + math.cos(angle) * world.width / 4
+        self.y = world.height / 2 + math.sin(angle) * world.height / 4
+
+    def begin_generation(self, world: World) -> None:
+        self._place(world)
+
+    def advance(self, world: World) -> None:
+        self._place(world)
+        radius = world.config.hazard_radius
+        for org in world.organisms:
+            if org.alive and math.dist((org.x, org.y), (self.x, self.y)) <= radius:
+                world.kill(org)
+
+    def survives(self, org: Organism, world: World) -> bool:
+        return org.alive
+
+    def zones(self, world: World) -> list[Shading]:
+        radius = world.config.hazard_radius
+        xs = np.arange(world.width)[:, None]
+        ys = np.arange(world.height)[None, :]
+        caught = (xs - self.x) ** 2 + (ys - self.y) ** 2 <= radius**2
+        return [Shading(caught, "Reds", "hazard")]
+
+
+def _build() -> dict[str, Objective]:
+    """The objectives offered on the command line and in the notebook."""
+    listed: list[Objective] = [
+        ReachZone("left", left_edge),
+        ReachZone("right", right_edge),
+        ReachZone("centre", centre),
+        ReachZone("corners", corners),
+        StayInZone("stay", left_edge),
+        StayInZone("stay-centre", centre),
+        VisitInOrder("there-and-back", right_edge, left_edge),
+        VisitInOrder("top-to-bottom", top_edge, bottom_edge),
+        Hazard(),
+    ]
+    return {objective.name: objective for objective in listed}
+
+
+OBJECTIVES: Final[dict[str, Objective]] = _build()

--- a/organism.py
+++ b/organism.py
@@ -2,9 +2,18 @@
 The organisms and the world they live in.
 
 A generation runs for `Settings.steps_per_generation` timesteps. At the end of
-it a survival criterion decides who reproduces; everybody else dies. Survivors
-are cloned with mutation until the population is full again, and the next
-generation starts from scratch on an empty grid.
+it an objective decides who reproduces; everybody else dies. Survivors are
+cloned with mutation until the population is full again, and the next
+generation starts from scratch on a cleared grid.
+
+The world holds three layers over the same grid:
+
+- `barriers`    solid cells, fixed for the whole run
+- `occupancy`   which cells hold a living organism, changing every step
+- `pheromone`   scent, deposited by organisms and decaying every step
+
+Barriers make navigation a real problem; pheromone is the only way one
+organism can change what another perceives.
 """
 
 from __future__ import annotations
@@ -14,9 +23,11 @@ from typing import TYPE_CHECKING, Final
 
 import numpy as np
 
+import barriers as barrier_layouts
 import brain_utils
 import settings
 from capability_utils import Action, Sensor, read_sensors
+from objectives import OBJECTIVES, Objective
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -33,9 +44,6 @@ DIRECTIONS: Final = (
     (1, -1), (1, 0), (1, 1),
 )  # fmt: skip
 
-type Criterion = Callable[[int, int, "World"], bool]
-"""Given a position and the world, decide whether an organism there survives."""
-
 
 class Organism:
     """
@@ -46,7 +54,19 @@ class Organism:
     actually consults is decided by its genome.
     """
 
-    __slots__ = ("age", "brain", "config", "genome", "last_dx", "last_dy", "name", "x", "y")
+    __slots__ = (
+        "age",
+        "alive",
+        "brain",
+        "config",
+        "genome",
+        "last_dx",
+        "last_dy",
+        "name",
+        "progress",
+        "x",
+        "y",
+    )
 
     def __init__(
         self,
@@ -66,6 +86,10 @@ class Organism:
         self.last_dx = 0
         self.last_dy = 0
         self.age = 0
+        self.alive = True
+
+        self.progress: dict[str, float] = {}
+        """Scratch space for objectives that accumulate history over a generation."""
 
     @property
     def placed(self) -> bool:
@@ -103,6 +127,11 @@ class Organism:
         urge_x += forward * self.last_dx
         urge_y += forward * self.last_dy
 
+        # A quarter turn to the left maps (dx, dy) -> (-dy, dx).
+        leftward = levels[Action.MOVE_LEFT]
+        urge_x += leftward * -self.last_dy
+        urge_y += leftward * self.last_dx
+
         if wander := levels[Action.MOVE_RANDOM]:
             dx, dy = random.choice(DIRECTIONS)
             urge_x += wander * dx
@@ -113,15 +142,18 @@ class Organism:
         urge_x *= 1.0 - stillness
         urge_y *= 1.0 - stillness
 
+        if (emission := levels[Action.EMIT_PHEROMONE]) > 0:
+            world.deposit_pheromone(self.x, self.y, emission * self.config.pheromone_deposit)
+
         self.move(_urge_to_step(urge_x), _urge_to_step(urge_y), world)
         self.age += 1
 
     def move(self, dx: int, dy: int, world: World) -> None:
         """
-        Try to step by (dx, dy), refusing moves into walls or occupied cells.
+        Try to step by (dx, dy), refusing moves into walls, barriers or organisms.
 
         A blocked diagonal falls back to whichever single axis is still open,
-        which lets organisms slide along a wall instead of sticking to it.
+        which lets organisms slide along an obstacle instead of sticking to it.
         """
         if dx == 0 and dy == 0:
             self.last_dx = self.last_dy = 0
@@ -135,7 +167,7 @@ class Organism:
                 self.last_dx, self.last_dy = step_x, step_y
                 return
 
-        # Fully boxed in: keep the heading so BLOCKED_FORWARD can report it.
+        # Fully boxed in: keep the heading so the blocked_* senses can report it.
         self.last_dx, self.last_dy = dx, dy
 
     # ------------------------------------------------------------------
@@ -152,7 +184,13 @@ class Organism:
         return Organism(self.config, genome=brain_utils.mutate(self.genome, self.config))
 
     def __repr__(self) -> str:
-        return f"<Organism at ({self.x}, {self.y})>"
+        state = "" if self.alive else ", dead"
+        return f"<Organism at ({self.x}, {self.y}){state}>"
+
+
+def _clamp(value: float) -> float:
+    """Hold a sensor reading inside [-1, 1]."""
+    return max(-1.0, min(1.0, value))
 
 
 def _urge_to_step(urge: float) -> int:
@@ -173,18 +211,19 @@ class World:
     The grid, the population living on it, and the generational cycle.
 
     Occupancy is kept in a numpy array alongside the organism list: the list is
-    what we iterate over, the array is what makes "is that cell taken?" and
-    "how crowded is it here?" cheap enough to ask on every timestep.
+    what we iterate over, the array is what makes "is that cell taken?", "how
+    crowded is it here?" and "which way are the others?" cheap enough to ask on
+    every timestep.
     """
 
     def __init__(
         self,
         config: Settings | None = None,
-        criterion: Criterion | None = None,
+        objective: Objective | str | None = None,
         n_organisms: int | None = None,
     ) -> None:
         self.config = config or settings.DEFAULT
-        self.criterion = criterion or left_edge
+        self.objective = _resolve_objective(objective)
         self.n_organisms = n_organisms if n_organisms is not None else self.config.n_organisms
 
         self.width = self.config.width
@@ -192,7 +231,15 @@ class World:
 
         self.generation = 0
         self.step = 0
+
+        self.barriers: npt.NDArray[np.bool_] = barrier_layouts.build(
+            self.config.barrier_layout, self.width, self.height
+        )
         self.occupancy: npt.NDArray[np.bool_] = np.zeros((self.width, self.height), dtype=bool)
+        self.pheromone: npt.NDArray[np.float32] = np.zeros(
+            (self.width, self.height), dtype=np.float32
+        )
+
         self.organisms: list[Organism] = self.build_initial_config()
 
     # ------------------------------------------------------------------
@@ -208,26 +255,29 @@ class World:
     def reset_grid(self, organisms: Iterable[Organism]) -> None:
         """Clear the grid and scatter the given organisms over empty cells."""
         self.occupancy[:, :] = False
+        self.pheromone[:, :] = 0.0
         self.step = 0
         for org in organisms:
             org.x = org.y = -1
             org.last_dx = org.last_dy = 0
             org.age = 0
+            org.alive = True
+            org.progress.clear()
             org.brain.reset()
             self.place(org, *self.random_empty_cell())
 
     def random_empty_cell(self) -> tuple[int, int]:
-        """Pick an unoccupied cell, falling back to a scan if the grid is crowded."""
+        """Pick a free, non-solid cell, falling back to a scan if the grid is crowded."""
         for _ in range(100):
             x = random.randrange(self.width)
             y = random.randrange(self.height)
-            if not self.occupancy[x, y]:
+            if not self.occupancy[x, y] and not self.barriers[x, y]:
                 return x, y
 
-        empty = np.argwhere(~self.occupancy)
-        if len(empty) == 0:
-            raise RuntimeError("no empty cells left: population exceeds grid size")
-        x, y = empty[random.randrange(len(empty))]
+        free = np.argwhere(~(self.occupancy | self.barriers))
+        if len(free) == 0:
+            raise RuntimeError("no free cells left: population exceeds the open grid")
+        x, y = free[random.randrange(len(free))]
         return int(x), int(y)
 
     # ------------------------------------------------------------------
@@ -241,7 +291,16 @@ class World:
         return bool(self.occupancy[x, y])
 
     def can_move_to(self, x: int, y: int) -> bool:
-        return self.in_bounds(x, y) and not self.occupancy[x, y]
+        return self.in_bounds(x, y) and not self.occupancy[x, y] and not self.barriers[x, y]
+
+    def _window_bounds(self, x: int, y: int, radius: int) -> tuple[int, int, int, int]:
+        """The neighbourhood around a cell, clipped to the grid."""
+        return (
+            max(0, x - radius),
+            min(self.width, x + radius + 1),
+            max(0, y - radius),
+            min(self.height, y + radius + 1),
+        )
 
     def population_density(self, x: int, y: int, radius: int) -> float:
         """
@@ -250,13 +309,81 @@ class World:
         The neighbourhood is clipped at the walls, so an organism in a corner
         does not read as lonely just because part of its window is off-grid.
         """
-        window = self.occupancy[
-            max(0, x - radius) : min(self.width, x + radius + 1),
-            max(0, y - radius) : min(self.height, y + radius + 1),
-        ]
+        x0, x1, y0, y1 = self._window_bounds(x, y, radius)
+        window = self.occupancy[x0:x1, y0:y1]
         neighbours = int(window.sum()) - 1  # discount the organism itself
         cells = window.size - 1
         return neighbours / cells if cells > 0 else 0.0
+
+    def neighbour_gradient(self, x: int, y: int, radius: int) -> tuple[float, float]:
+        """
+        Which way the neighbours lie, as a signed pair in [-1, 1].
+
+        (+1, 0) means every neighbour in range is east; (0, 0) means they are
+        balanced, or that there are none. This is the directional information
+        `population_density` throws away.
+        """
+        x0, x1, y0, y1 = self._window_bounds(x, y, radius)
+        window = self.occupancy[x0:x1, y0:y1]
+        total = int(window.sum()) - 1
+        if total <= 0:
+            return 0.0, 0.0
+
+        east = int(self.occupancy[x + 1 : x1, y0:y1].sum())
+        west = int(self.occupancy[x0:x, y0:y1].sum())
+        north = int(self.occupancy[x0:x1, y + 1 : y1].sum())
+        south = int(self.occupancy[x0:x1, y0:y].sum())
+        return _clamp((east - west) / total), _clamp((north - south) / total)
+
+    def nearest_neighbour(self, x: int, y: int, radius: int) -> float:
+        """
+        Closeness of the nearest other organism: 1 when adjacent, 0 when none is in range.
+
+        The empty case is the common one in a sparse world, so it is settled
+        with a single array sum before doing any real work.
+        """
+        x0, x1, y0, y1 = self._window_bounds(x, y, radius)
+        window = self.occupancy[x0:x1, y0:y1]
+        if int(window.sum()) <= 1:
+            return 0.0
+
+        others = np.argwhere(window)
+        dx = others[:, 0] + x0 - x
+        dy = others[:, 1] + y0 - y
+        distances = np.maximum(np.abs(dx), np.abs(dy))  # Chebyshev: one step per ring
+        nearest = int(distances[distances > 0].min())
+        return max(0.0, 1.0 - (nearest - 1) / radius)
+
+    # ------------------------------------------------------------------
+    # The pheromone layer
+    # ------------------------------------------------------------------
+
+    def pheromone_at(self, x: int, y: int) -> float:
+        """Scent on one cell, saturating at 1."""
+        return min(float(self.pheromone[x, y]), 1.0)
+
+    def pheromone_gradient(self, x: int, y: int, radius: int) -> tuple[float, float]:
+        """Which way the scent gets stronger, as a signed pair in [-1, 1]."""
+        x0, x1, y0, y1 = self._window_bounds(x, y, radius)
+        total = float(self.pheromone[x0:x1, y0:y1].sum())
+        if total <= 0.0:
+            return 0.0, 0.0
+
+        east = float(self.pheromone[x + 1 : x1, y0:y1].sum())
+        west = float(self.pheromone[x0:x, y0:y1].sum())
+        north = float(self.pheromone[x0:x1, y + 1 : y1].sum())
+        south = float(self.pheromone[x0:x1, y0:y].sum())
+        # The sub-sums are float32 while the total is not, so rounding can push
+        # a ratio a hair past 1. Clamp, or a sensor quietly breaks its contract.
+        return _clamp((east - west) / total), _clamp((north - south) / total)
+
+    def deposit_pheromone(self, x: int, y: int, amount: float) -> None:
+        """Lay scent on a cell. Deposits accumulate; sensing saturates at 1."""
+        self.pheromone[x, y] += amount
+
+    # ------------------------------------------------------------------
+    # Placing and removing organisms
+    # ------------------------------------------------------------------
 
     def place(self, org: Organism, x: int, y: int) -> None:
         org.x, org.y = x, y
@@ -267,21 +394,33 @@ class World:
         self.occupancy[x, y] = True
         org.x, org.y = x, y
 
+    def kill(self, org: Organism) -> None:
+        """Remove an organism from play. It keeps its position but frees its cell."""
+        if not org.alive:
+            return
+        org.alive = False
+        self.occupancy[org.x, org.y] = False
+
+    def living(self) -> list[Organism]:
+        return [org for org in self.organisms if org.alive]
+
     # ------------------------------------------------------------------
     # Running time
     # ------------------------------------------------------------------
 
     def update_organisms(self) -> None:
         """
-        Advance every organism by one timestep.
+        Advance every living organism by one timestep, then age the world.
 
         The order is shuffled each step so that no organism gets a permanent
         advantage in claiming contested cells.
         """
-        order = list(self.organisms)
+        order = self.living()
         random.shuffle(order)
         for org in order:
             org.act(self)
+
+        self.pheromone *= self.config.pheromone_decay
         self.step += 1
 
     def run_generation(self, on_step: Callable[[World, int], None] | None = None) -> int:
@@ -291,10 +430,16 @@ class World:
         `on_step` is called with (world, step) after each timestep, which is how
         `execute.py` draws the animation without the world knowing about it.
 
-        Returns the number of organisms that met the survival criterion.
+        Returns the number of organisms that met the objective.
         """
+        self.objective.begin_generation(self)
+
         for step in range(self.config.steps_per_generation):
             self.update_organisms()
+            self.objective.advance(self)
+            for org in self.organisms:
+                if org.alive:
+                    self.objective.observe(org, self)
             if on_step is not None:
                 on_step(self, step)
 
@@ -304,8 +449,8 @@ class World:
         return len(survivors)
 
     def select_survivors(self) -> list[Organism]:
-        """The organisms that satisfy the survival criterion. Everyone else dies."""
-        return [org for org in self.organisms if self.criterion(org.x, org.y, self)]
+        """The organisms that satisfy the objective. Everyone else dies."""
+        return [org for org in self.organisms if org.alive and self.objective.survives(org, self)]
 
     def reproduce_organisms(self, survivors: list[Organism]) -> None:
         """
@@ -324,63 +469,21 @@ class World:
         self.reset_grid(children)
 
     def positions(self) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]:
-        """Current x and y arrays for the whole population, for plotting."""
-        count = len(self.organisms)
-        xs = np.fromiter((org.x for org in self.organisms), dtype=int, count=count)
-        ys = np.fromiter((org.y for org in self.organisms), dtype=int, count=count)
+        """Current x and y arrays for the living population, for plotting."""
+        alive = self.living()
+        xs = np.fromiter((org.x for org in alive), dtype=int, count=len(alive))
+        ys = np.fromiter((org.y for org in alive), dtype=int, count=len(alive))
         return xs, ys
 
-    def survival_zone_mask(self) -> npt.NDArray[np.bool_]:
-        """
-        A boolean grid of the cells that count as survivable.
 
-        Rather than hard-coding a shape per criterion, this asks the criterion
-        itself about every cell, so any new criterion draws itself correctly.
-        """
-        return np.array(
-            [[self.criterion(x, y, self) for y in range(self.height)] for x in range(self.width)],
-            dtype=bool,
-        )
-
-
-# ----------------------------------------------------------------------------
-# Survival criteria
-# ----------------------------------------------------------------------------
-#
-# A criterion takes a position and the world, and returns True if an organism
-# ending the generation there gets to reproduce. This is the entire selection
-# pressure -- swapping the criterion is the main dial for changing what evolves.
-
-
-def left_edge(x: int, y: int, world: World) -> bool:
-    """Survive by ending the generation in a band along the west wall."""
-    return x < world.width * world.config.survival_zone_fraction
-
-
-def right_edge(x: int, y: int, world: World) -> bool:
-    """Survive by ending the generation in a band along the east wall."""
-    return x >= world.width * (1 - world.config.survival_zone_fraction)
-
-
-def centre(x: int, y: int, world: World) -> bool:
-    """Survive by ending the generation inside a circle at the middle of the world."""
-    radius = world.width * world.config.survival_zone_fraction
-    dx = x - world.width / 2
-    dy = y - world.height / 2
-    return dx * dx + dy * dy <= radius * radius
-
-
-def corners(x: int, y: int, world: World) -> bool:
-    """Survive by ending the generation in any of the four corners."""
-    span = world.width * world.config.survival_zone_fraction
-    near_x = x < span or x >= world.width - span
-    near_y = y < span or y >= world.height - span
-    return near_x and near_y
-
-
-CRITERIA: Final[dict[str, Criterion]] = {
-    "left": left_edge,
-    "right": right_edge,
-    "centre": centre,
-    "corners": corners,
-}
+def _resolve_objective(objective: Objective | str | None) -> Objective:
+    """Accept an objective, the name of one, or nothing at all."""
+    if objective is None:
+        return OBJECTIVES["left"]
+    if isinstance(objective, str):
+        try:
+            return OBJECTIVES[objective]
+        except KeyError:
+            known = ", ".join(OBJECTIVES)
+            raise ValueError(f"unknown objective {objective!r}; try one of: {known}") from None
+    return objective

--- a/sandbox.ipynb
+++ b/sandbox.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# Goal and functionality of algorithm\n",
@@ -21,6 +22,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "source": [
     "# What does the MVP look like?\n",
@@ -33,12 +35,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
    "source": [
     "---\n",
     "# Scratchpad\n",
     "\n",
-    "The MVP above is built. `uv run python execute.py` runs it with the animation; the cells below are for poking at individual creatures and working out *why* a behaviour appeared.\n",
+    "The MVP above is built and then some. `uv run python execute.py` runs it with the animation; the cells below are for poking at individual creatures and working out *why* a behaviour appeared.\n",
     "\n",
     "The answer to \"does this always need to look like [perception] -> [action]\" turned out to be no: inner neurons keep their value between timesteps, so a genome can wire perception -> memory -> action, or a loop that ignores perception entirely.\n",
     "\n",
@@ -48,12 +51,72 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "outputs": [],
-   "source": "%matplotlib inline\nfrom dataclasses import replace\n\nimport matplotlib.pyplot as plt\n\nfrom capability_utils import Action\nfrom organism import CRITERIA, World\nfrom settings import Settings\n\nconfig = Settings()"
+   "source": [
+    "%matplotlib inline\n",
+    "from dataclasses import replace\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import inspect_utils\n",
+    "from capability_utils import Action\n",
+    "from organism import World\n",
+    "from settings import Settings\n",
+    "\n",
+    "config = Settings()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def draw_world(world, ax, title):\n",
+    "    \"\"\"Zones, scent, barriers and creatures, in the order they should stack.\"\"\"\n",
+    "    extent = (0, world.width, 0, world.height)\n",
+    "    for shading in world.objective.zones(world):\n",
+    "        ax.imshow(\n",
+    "            shading.mask.T,\n",
+    "            origin=\"lower\",\n",
+    "            cmap=shading.colour,\n",
+    "            alpha=0.3,\n",
+    "            extent=extent,\n",
+    "            vmin=0,\n",
+    "            vmax=1,\n",
+    "        )\n",
+    "    ax.imshow(\n",
+    "        world.pheromone.T.clip(0, 1),\n",
+    "        origin=\"lower\",\n",
+    "        cmap=\"BuPu\",\n",
+    "        alpha=0.55,\n",
+    "        extent=extent,\n",
+    "        vmin=0,\n",
+    "        vmax=1,\n",
+    "    )\n",
+    "    ax.imshow(\n",
+    "        np.ma.masked_where(~world.barriers.T, world.barriers.T),\n",
+    "        origin=\"lower\",\n",
+    "        cmap=\"Greys\",\n",
+    "        alpha=0.85,\n",
+    "        extent=extent,\n",
+    "        vmin=0,\n",
+    "        vmax=1,\n",
+    "    )\n",
+    "    xs, ys = world.positions()\n",
+    "    ax.scatter(xs, ys, s=7)\n",
+    "    ax.set_title(title)\n",
+    "    ax.set_xlim(0, world.width)\n",
+    "    ax.set_ylim(0, world.height)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "source": [
     "## One organism, up close"
@@ -62,6 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,6 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,6 +152,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The same brain as a picture: blue excites, orange inhibits,\n",
+    "# and thickness follows the weight.\n",
+    "inspect_utils.draw_brain(org.brain, config);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,6 +175,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
    "source": [
     "## Watching a population evolve"
@@ -105,10 +184,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "938c804e27f84196a10c8828c723f798",
    "metadata": {},
    "outputs": [],
    "source": [
-    "world = World(config=config, criterion=CRITERIA[\"left\"])\n",
+    "world = World(config=config, objective=\"left\")\n",
     "\n",
     "history = [world.run_generation() / world.n_organisms for _ in range(40)]\n",
     "\n",
@@ -121,12 +201,75 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "504fb2a444614c0babb325280ed9130a",
    "metadata": {},
    "outputs": [],
-   "source": "# Where an evolved generation ends up, versus where it started.\nstart_x, start_y = world.positions()\nworld.run_generation()\nend_x, end_y = world.positions()\n\nfigure, axes = plt.subplots(1, 2, figsize=(10, 5), sharex=True, sharey=True)\nfor ax, (xs, ys), title in zip(\n    axes,\n    [(start_x, start_y), (end_x, end_y)],\n    [\"start of generation\", \"end of generation\"],\n    strict=True,\n):\n    ax.imshow(\n        world.survival_zone_mask().T,\n        origin=\"lower\",\n        cmap=\"Greens\",\n        alpha=0.25,\n        extent=(0, world.width, 0, world.height),\n    )\n    ax.scatter(xs, ys, s=6)\n    ax.set_title(title)\n    ax.set_xlim(0, world.width)\n    ax.set_ylim(0, world.height)"
+   "source": [
+    "# Where an evolved generation ends up, versus where it started.\n",
+    "figure, axes = plt.subplots(1, 2, figsize=(11, 5.5), sharex=True, sharey=True)\n",
+    "draw_world(world, axes[0], \"start of generation\")\n",
+    "world.run_generation()\n",
+    "draw_world(world, axes[1], \"end of generation\")"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
+   "metadata": {},
+   "source": [
+    "## Obstacles and scent\n",
+    "\n",
+    "Barriers turn \"head west\" from a complete solution into one that strands a creature in a dead end. Pheromone is the only channel one creature has for changing what another perceives — look for trails in the purple layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b43b363d81ae4b689946ece5c682cd59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hard = replace(config, barrier_layout=\"slalom\")\n",
+    "maze = World(config=hard, objective=\"left\")\n",
+    "for _ in range(25):\n",
+    "    maze.run_generation()\n",
+    "\n",
+    "figure, ax = plt.subplots(figsize=(6.5, 6.5))\n",
+    "maze.run_generation()\n",
+    "draw_world(maze, ax, \"after 25 generations against the slalom\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
+   "metadata": {},
+   "source": [
+    "## Racing objectives against each other"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3933fab20d04ec698c2621248eb3be0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quick = replace(config, n_organisms=150, steps_per_generation=120)\n",
+    "\n",
+    "for name in [\"left\", \"corners\", \"stay\", \"hazard\"]:\n",
+    "    trial = World(config=quick, objective=name)\n",
+    "    curve = [trial.run_generation() / quick.n_organisms for _ in range(25)]\n",
+    "    plt.plot(curve, label=name)\n",
+    "\n",
+    "plt.xlabel(\"generation\")\n",
+    "plt.ylabel(\"fraction surviving\")\n",
+    "plt.ylim(0, 1)\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd4641cc4064e0191573fe9c69df29b",
    "metadata": {},
    "source": [
     "## Changing the rules without touching the code\n",
@@ -137,13 +280,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8309879909854d7188b41380fd92a7c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "# How much does the mutation rate matter?\n",
     "for rate in [0.005, 0.02, 0.08]:\n",
-    "    tuned = replace(config, point_mutation_rate=rate, n_organisms=150, steps_per_generation=100)\n",
-    "    trial = World(config=tuned, criterion=CRITERIA[\"corners\"])\n",
+    "    tuned = replace(config, point_mutation_rate=rate, n_organisms=150, steps_per_generation=120)\n",
+    "    trial = World(config=tuned, objective=\"corners\")\n",
     "    curve = [trial.run_generation() / tuned.n_organisms for _ in range(25)]\n",
     "    plt.plot(curve, label=f\"mutation rate {rate}\")\n",
     "\n",
@@ -155,13 +299,37 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3ed186c9a28b402fb0bc4494df01f08d",
+   "metadata": {},
+   "source": [
+    "## Keeping a creature you like"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb1e1581032b452c9409d6c6813c49d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best = world.organisms[0]\n",
+    "inspect_utils.save_genome(best.genome, config, \"good_creature.json\")\n",
+    "\n",
+    "restored = inspect_utils.load_genome(\"good_creature.json\")\n",
+    "print(\"round-trips exactly:\", restored == best.genome)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "379cbbc1e968416e875cc15c1202d7eb",
    "metadata": {},
    "source": [
     "## Ideas to try\n",
     "\n",
-    "- A new survival criterion at the bottom of `organism.py` (the animation shades any zone automatically).\n",
-    "- A new member of `Sensor` or `Action` in `capability_utils.py` -- evolution picks it up on the next run with no other changes.\n",
-    "- Crossover between two survivors, instead of the current asexual mutation-only reproduction."
+    "- A new objective in `objectives.py` — the animation draws its zones automatically.\n",
+    "- A new member of `Sensor` or `Action` in `capability_utils.py` — evolution picks it up on the next run with no other changes.\n",
+    "- Crossover between two survivors, instead of the current asexual mutation-only reproduction.\n",
+    "- Partial credit in selection, so hard objectives have a gradient to climb instead of reseeding from scratch whenever nobody survives."
    ]
   }
  ],

--- a/settings.py
+++ b/settings.py
@@ -18,10 +18,24 @@ class Settings:
     width: int = 100
     height: int = 100
 
+    barrier_layout: str = "none"
+    """Which obstacle layout to build into the world. See `barriers.LAYOUTS`."""
+
     # Population and timing
     n_organisms: int = 250
     steps_per_generation: int = 200
     n_generations: int = 100
+
+    # Perception
+    sense_radius: int = 6
+    """How far an organism can feel neighbours and smell pheromone."""
+
+    # The pheromone layer
+    pheromone_decay: float = 0.92
+    """Fraction of the pheromone on a cell that survives each timestep."""
+
+    pheromone_deposit: float = 0.5
+    """How much an organism lays down at full emission strength."""
 
     # Brain structure
     n_inner_neurons: int = 4
@@ -42,7 +56,16 @@ class Settings:
 
     # Selection
     survival_zone_fraction: float = 0.2
-    """Fraction of the world's width that the survival criteria treat as safe."""
+    """Fraction of the world's width that the zone objectives treat as safe."""
+
+    stay_fraction: float = 0.5
+    """For `stay`: the fraction of the generation that must be spent in the zone."""
+
+    hazard_radius: float = 12.0
+    """For `hazard`: radius of the roaming danger circle."""
+
+    hazard_period: int = 100
+    """For `hazard`: timesteps the hazard takes to complete one circuit."""
 
 
 DEFAULT = Settings()

--- a/test_simulation.py
+++ b/test_simulation.py
@@ -5,22 +5,28 @@ Sanity checks for the simulation. Run with:
 
 These are deliberately about invariants rather than exact values -- the whole
 system is stochastic, so anything asserting a specific outcome would be flaky.
-What must always hold is that organisms stay on the grid, never share a cell,
-and that mutation only ever produces genes that can be wired up.
+What must always hold is that organisms stay on the grid, never share a cell or
+stand inside a wall, that mutation only produces genes that can be wired up,
+and that every objective can actually be satisfied.
 """
 
 from __future__ import annotations
 
 import random
 from dataclasses import replace
+from pathlib import Path
 
 import numpy as np
 import pytest
 
+import barriers
 import brain_utils
+import inspect_utils
+import objectives
 from brain_utils import Brain, Gene, Sink, Source
-from capability_utils import Action, Sensor
-from organism import CRITERIA, Organism, World
+from capability_utils import SENSOR_FUNCTIONS, Action, Sensor
+from objectives import OBJECTIVES, Hazard, StayInZone, VisitInOrder
+from organism import Organism, World
 from settings import Settings
 
 
@@ -35,6 +41,14 @@ def _deterministic() -> None:
 def config() -> Settings:
     """A small, fast world for tests that do not care about scale."""
     return replace(Settings(), n_organisms=40, steps_per_generation=30)
+
+
+def lone_world(config: Settings, **kwargs: object) -> tuple[World, Organism]:
+    """A world holding exactly one organism, parked in the middle."""
+    world = World(config=config, n_organisms=1, **kwargs)  # type: ignore[arg-type]
+    org = world.organisms[0]
+    world.relocate(org, world.width // 2, world.height // 2)
+    return world, org
 
 
 # ----------------------------------------------------------------------------
@@ -58,8 +72,7 @@ def test_organisms_do_not_get_stuck_at_the_walls(config: Settings) -> None:
     This is the failure the original `move` had: its bounds check froze any
     organism that stepped onto the boundary.
     """
-    world = World(config=config, n_organisms=1)
-    org = world.organisms[0]
+    world, org = lone_world(config)
     middle = world.height // 2
     world.relocate(org, 0, middle)
 
@@ -76,9 +89,9 @@ def test_one_organism_per_cell(config: Settings) -> None:
     for _ in range(120):
         world.update_organisms()
 
-    cells = {(org.x, org.y) for org in world.organisms}
-    assert len(cells) == len(world.organisms), "two organisms share a cell"
-    assert int(world.occupancy.sum()) == len(world.organisms), (
+    cells = {(org.x, org.y) for org in world.living()}
+    assert len(cells) == len(world.living()), "two organisms share a cell"
+    assert int(world.occupancy.sum()) == len(world.living()), (
         "occupancy grid disagrees with the population"
     )
 
@@ -94,24 +107,205 @@ def test_blocked_moves_are_refused(config: Settings) -> None:
     assert (first.x, first.y) == (10, 10), "organism moved into an occupied cell"
 
 
-def test_population_density_ignores_the_organism_itself(config: Settings) -> None:
-    """An organism alone in an empty world should read zero density."""
-    world = World(config=config, n_organisms=1)
-    world.relocate(world.organisms[0], 50, 50)
-    assert world.population_density(50, 50, 4) == 0.0, "an organism sensed itself"
-
-
-def test_population_density_saturates_when_crowded(config: Settings) -> None:
-    """A fully occupied neighbourhood should read as fully dense."""
-    world = World(config=config, n_organisms=1)
-    world.occupancy[48:53, 48:53] = True
-    assert world.population_density(50, 50, 2) == 1.0
-
-
 def test_every_organism_is_placed_on_the_grid(config: Settings) -> None:
     """No organism may be left without a cell after the world is built."""
     world = World(config=config)
     assert all(org.placed for org in world.organisms)
+
+
+# ----------------------------------------------------------------------------
+# Barriers
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("layout", sorted(barriers.LAYOUTS))
+def test_layouts_have_the_right_shape_and_leave_room(layout: str) -> None:
+    """Every layout must fit the world and leave most of it walkable."""
+    grid = barriers.build(layout, 100, 100)
+    assert grid.shape == (100, 100)
+    assert grid.dtype == np.bool_
+    assert grid.mean() < 0.5, f"{layout} fills too much of the world"
+
+
+def test_unknown_layout_is_reported_clearly() -> None:
+    with pytest.raises(ValueError, match="unknown barrier layout"):
+        barriers.build("swiss-cheese", 20, 20)
+
+
+@pytest.mark.parametrize("layout", sorted(barriers.LAYOUTS))
+def test_organisms_never_stand_inside_a_barrier(layout: str, config: Settings) -> None:
+    """Placement and movement must both respect solid cells."""
+    world = World(config=replace(config, barrier_layout=layout))
+    for _ in range(60):
+        world.update_organisms()
+        for org in world.living():
+            assert not world.barriers[org.x, org.y], f"{layout}: organism inside a wall"
+
+
+def test_barriers_block_movement(config: Settings) -> None:
+    """A solid cell refuses entry just as a world edge does."""
+    world, org = lone_world(config)
+    world.barriers[org.x + 1, org.y] = True
+    assert not world.can_move_to(org.x + 1, org.y)
+
+    before = org.x
+    org.move(1, 0, world)
+    assert org.x == before, "organism walked into a barrier"
+
+
+# ----------------------------------------------------------------------------
+# Senses
+# ----------------------------------------------------------------------------
+
+
+def test_every_sensor_stays_in_range(config: Settings) -> None:
+    """A sensor outside [-1, 1] would quietly dominate every brain that used it."""
+    world = World(config=replace(config, barrier_layout="pillars"))
+    for _ in range(25):
+        world.update_organisms()
+        for org in world.living():
+            for sensor, value in org.perceive(world).items():
+                assert -1.0 <= value <= 1.0, f"{sensor} out of range: {value}"
+
+
+def test_perceive_reports_every_sensor(config: Settings) -> None:
+    """The debugging view must cover the full sensor list."""
+    world = World(config=config)
+    assert set(world.organisms[0].perceive(world)) == set(Sensor)
+
+
+def test_neighbour_gradient_points_at_the_neighbours(config: Settings) -> None:
+    """The directional sense must actually be directional."""
+    world, org = lone_world(config)
+    x, y = org.x, org.y
+
+    assert world.neighbour_gradient(x, y, 6) == (0.0, 0.0), "alone should read as balanced"
+
+    world.occupancy[x + 3, y] = True
+    east, north = world.neighbour_gradient(x, y, 6)
+    assert east == pytest.approx(1.0)
+    assert north == pytest.approx(0.0)
+
+    world.occupancy[x - 3, y] = True
+    east, _ = world.neighbour_gradient(x, y, 6)
+    assert east == pytest.approx(0.0), "neighbours on both sides should cancel"
+
+    world.occupancy[x, y + 2] = True
+    _, north = world.neighbour_gradient(x, y, 6)
+    assert north > 0
+
+
+def test_nearest_neighbour_falls_off_with_distance(config: Settings) -> None:
+    """1 when adjacent, 0 when nothing is in range, decreasing in between."""
+    world, org = lone_world(config)
+    x, y = org.x, org.y
+    assert world.nearest_neighbour(x, y, 6) == 0.0
+
+    world.occupancy[x + 1, y] = True
+    assert world.nearest_neighbour(x, y, 6) == pytest.approx(1.0)
+
+    world.occupancy[x + 1, y] = False
+    world.occupancy[x + 4, y] = True
+    close = world.nearest_neighbour(x, y, 6)
+    assert 0.0 < close < 1.0
+
+
+def test_population_density_ignores_the_organism_itself(config: Settings) -> None:
+    """An organism alone in an empty world should read zero density."""
+    world, org = lone_world(config)
+    assert world.population_density(org.x, org.y, 4) == 0.0, "an organism sensed itself"
+
+
+def test_population_density_saturates_when_crowded(config: Settings) -> None:
+    """A fully occupied neighbourhood should read as fully dense."""
+    world, org = lone_world(config)
+    x, y = org.x, org.y
+    world.occupancy[x - 2 : x + 3, y - 2 : y + 3] = True
+    assert world.population_density(x, y, 2) == 1.0
+
+
+def test_blocked_senses_rotate_with_the_heading(config: Settings) -> None:
+    """
+    Left and right must be relative to where the organism is going.
+
+    Heading east, 'left' is north -- getting the rotation backwards would give
+    evolution a consistently mirrored world, which is hard to spot by eye.
+    """
+    world, org = lone_world(config)
+    org.last_dx, org.last_dy = 1, 0  # heading east
+
+    world.barriers[org.x, org.y + 1] = True  # a wall to the north
+    assert SENSOR_FUNCTIONS[Sensor.BLOCKED_LEFT](org, world) == 1.0
+    assert SENSOR_FUNCTIONS[Sensor.BLOCKED_RIGHT](org, world) == 0.0
+    assert SENSOR_FUNCTIONS[Sensor.BLOCKED_FORWARD](org, world) == 0.0
+
+    world.barriers[org.x, org.y + 1] = False
+    world.barriers[org.x + 1, org.y] = True  # a wall dead ahead
+    assert SENSOR_FUNCTIONS[Sensor.BLOCKED_FORWARD](org, world) == 1.0
+
+
+def test_a_still_organism_reads_nothing_as_blocked(config: Settings) -> None:
+    """With no heading there is no forward, left or right to report."""
+    world, org = lone_world(config)
+    org.last_dx = org.last_dy = 0
+    for sensor in (Sensor.BLOCKED_FORWARD, Sensor.BLOCKED_LEFT, Sensor.BLOCKED_RIGHT):
+        assert SENSOR_FUNCTIONS[sensor](org, world) == 0.0
+
+
+# ----------------------------------------------------------------------------
+# The pheromone layer
+# ----------------------------------------------------------------------------
+
+
+def test_pheromone_saturates_but_accumulates(config: Settings) -> None:
+    """Sensing tops out at 1 even though deposits keep stacking."""
+    world, org = lone_world(config)
+    world.deposit_pheromone(org.x, org.y, 0.4)
+    assert world.pheromone_at(org.x, org.y) == pytest.approx(0.4)
+
+    for _ in range(10):
+        world.deposit_pheromone(org.x, org.y, 0.4)
+    assert world.pheromone_at(org.x, org.y) == 1.0
+
+
+def test_pheromone_decays_over_time(config: Settings) -> None:
+    """Trails must fade, or the whole grid saturates and the sense goes blind."""
+    world, org = lone_world(config)
+    world.deposit_pheromone(org.x, org.y, 1.0)
+    before = world.pheromone_at(org.x, org.y)
+
+    for _ in range(5):
+        world.update_organisms()
+
+    assert world.pheromone_at(org.x, org.y) < before
+
+
+def test_pheromone_gradient_points_up_the_trail(config: Settings) -> None:
+    """Following a scent is only possible if the gradient has the right sign."""
+    world, org = lone_world(config)
+    x, y = org.x, org.y
+    assert world.pheromone_gradient(x, y, 6) == (0.0, 0.0), "unscented should read as balanced"
+
+    world.deposit_pheromone(x + 3, y, 1.0)
+    east, north = world.pheromone_gradient(x, y, 6)
+    assert east == pytest.approx(1.0)
+    assert north == pytest.approx(0.0)
+
+    world.deposit_pheromone(x, y - 3, 1.0)
+    _, north = world.pheromone_gradient(x, y, 6)
+    assert north < 0
+
+
+def test_emitting_leaves_scent_where_the_organism_stands(config: Settings) -> None:
+    """The emit action has to reach the grid, not just the brain's output."""
+    genome = (Gene(Source.SENSOR, Sensor.BIAS, Sink.ACTION, Action.EMIT_PHEROMONE, 4.0),)
+    world, _ = lone_world(config)
+    org = Organism(config, genome=genome)
+    world.reset_grid([*world.organisms, org])
+
+    x, y = org.x, org.y
+    org.act(world)
+    assert world.pheromone[x, y] > 0.0
 
 
 # ----------------------------------------------------------------------------
@@ -163,7 +357,7 @@ def test_brains_produce_one_bounded_level_per_action(config: Settings) -> None:
     """`think` must return a usable level for every action, every time."""
     world = World(config=config)
     for _ in range(20):
-        for org in world.organisms:
+        for org in world.living():
             levels = org.brain.think(org, world)
             assert len(levels) == len(Action)
             assert all(-1.0 <= level <= 1.0 for level in levels)
@@ -183,36 +377,26 @@ def test_inner_neurons_carry_state_between_timesteps(config: Settings) -> None:
     A recurrent loop with no sensor input must still drive an action.
 
     This is what makes memory reachable by evolution, so it is worth pinning
-    rather than trusting to a random genome to exercise it.
+    rather than trusting a random genome to exercise it.
     """
     genome = (
         Gene(Source.SENSOR, Sensor.BIAS, Sink.INNER, 0, 2.0),
         Gene(Source.INNER, 0, Sink.INNER, 1, 2.0),
         Gene(Source.INNER, 1, Sink.ACTION, Action.MOVE_X, 2.0),
     )
-    world = World(config=config, n_organisms=1)
+    world, _ = lone_world(config)
     org = Organism(config, genome=genome)
     world.place(org, 5, 5)
 
     # Inner neuron 1 starts at zero, so the action is silent on the first step
     # and only responds once the signal has propagated through the loop.
-    assert world  # keep the world alive for the sensor calls
     first = org.brain.think(org, world)[Action.MOVE_X]
     second = org.brain.think(org, world)[Action.MOVE_X]
     assert first == pytest.approx(0.0)
     assert second > 0.5
 
 
-def test_perceive_reports_every_sensor(config: Settings) -> None:
-    """The debugging view must cover the full sensor list, in range."""
-    world = World(config=config)
-    knowledge = world.organisms[0].perceive(world)
-    assert set(knowledge) == set(Sensor)
-    for sensor, value in knowledge.items():
-        assert -1.0 <= value <= 1.0, f"{sensor} out of range: {value}"
-
-
-def test_gene_describe_names_its_endpoints(config: Settings) -> None:
+def test_gene_describe_names_its_endpoints() -> None:
     """The wiring readout is the main way behaviour gets explained, so pin its shape."""
     gene = Gene(Source.SENSOR, Sensor.BORDER_DISTANCE, Sink.ACTION, Action.MOVE_X, -2.134)
     assert gene.describe() == "border_distance --(-2.13)--> move_x"
@@ -222,7 +406,7 @@ def test_gene_describe_names_its_endpoints(config: Settings) -> None:
 
 
 # ----------------------------------------------------------------------------
-# Selection and reproduction
+# Objectives
 # ----------------------------------------------------------------------------
 
 
@@ -235,37 +419,113 @@ def test_a_generation_preserves_population_size(config: Settings) -> None:
         for org in world.organisms:
             assert org.placed, "organism was never placed"
             assert org.age == 0, "a new generation should start at age zero"
+            assert org.alive, "a new generation should start alive"
 
 
 def test_extinction_reseeds_rather_than_ending_the_run(config: Settings) -> None:
     """With no survivors the world must refill itself instead of emptying."""
-    world = World(config=config, criterion=lambda x, y, w: False)
+
+    class Impossible(objectives.Objective):
+        name = "impossible"
+
+        def survives(self, org: Organism, world: World) -> bool:
+            return False
+
+    world = World(config=config, objective=Impossible())
     world.run_generation()
     assert len(world.organisms) == config.n_organisms
 
 
-@pytest.mark.parametrize("name", sorted(CRITERIA))
-def test_survivors_are_exactly_those_in_the_zone(name: str, config: Settings) -> None:
-    """Selection must return every organism inside the survival zone, and no others."""
-    criterion = CRITERIA[name]
-    world = World(config=config, criterion=criterion)
+@pytest.mark.parametrize("name", list(OBJECTIVES))
+def test_every_objective_runs_and_can_be_drawn(name: str, config: Settings) -> None:
+    """Each objective must survive a generation and describe its own zones."""
+    world = World(config=config, objective=name)
+    survivors = world.run_generation()
+    assert 0 <= survivors <= config.n_organisms
+
+    for shading in world.objective.zones(world):
+        assert shading.mask.shape == (world.width, world.height)
+        assert shading.mask.any(), f"{name}: zone {shading.label} is empty"
+
+
+def test_unknown_objective_is_reported_clearly(config: Settings) -> None:
+    with pytest.raises(ValueError, match="unknown objective"):
+        World(config=config, objective="become-immortal")
+
+
+def test_reach_zone_selects_exactly_those_in_the_zone(config: Settings) -> None:
+    """Selection must return every organism inside the zone, and no others."""
+    objective = OBJECTIVES["left"]
+    world = World(config=config, objective=objective)
     for _ in range(30):
         world.update_organisms()
 
     survivors = set(map(id, world.select_survivors()))
     for org in world.organisms:
-        assert criterion(org.x, org.y, world) == (id(org) in survivors)
+        assert objective.survives(org, world) == (id(org) in survivors)
 
 
-@pytest.mark.parametrize("name", sorted(CRITERIA))
-def test_survival_zone_mask_agrees_with_the_criterion(name: str, config: Settings) -> None:
-    """The shading the animation draws must match the selection actually applied."""
-    world = World(config=config, criterion=CRITERIA[name])
-    mask = world.survival_zone_mask()
-    assert mask.shape == (world.width, world.height)
-    assert mask.any(), f"{name}: survival zone is empty"
-    for x, y in [(0, 0), (world.width - 1, world.height - 1), (world.width // 2, 3)]:
-        assert bool(mask[x, y]) == CRITERIA[name](x, y, world)
+def test_stay_in_zone_needs_time_not_just_arrival(config: Settings) -> None:
+    """Ending in the zone is not enough if the organism only just got there."""
+    objective = StayInZone("stay-test", objectives.left_edge, fraction=0.5)
+    world = World(config=config, objective=objective, n_organisms=1)
+    org = world.organisms[0]
+
+    objective.begin_generation(world)
+    world.relocate(org, 1, 5)  # inside the zone, but with no history
+    assert not objective.survives(org, world)
+
+    required = int(0.5 * config.steps_per_generation)
+    for _ in range(required):
+        objective.observe(org, world)
+    assert objective.survives(org, world)
+
+
+def test_visit_in_order_requires_both_halves(config: Settings) -> None:
+    """Finishing in the second zone without touching the first must not count."""
+    objective = VisitInOrder("order-test", objectives.right_edge, objectives.left_edge)
+    world = World(config=config, objective=objective, n_organisms=1)
+    org = world.organisms[0]
+
+    objective.begin_generation(world)
+    world.relocate(org, 1, 5)  # in the finishing zone, never visited the first
+    assert not objective.survives(org, world)
+
+    world.relocate(org, world.width - 2, 5)  # touch the first zone
+    objective.observe(org, world)
+    assert not objective.survives(org, world), "visiting the first zone alone is not enough"
+
+    world.relocate(org, 1, 5)
+    assert objective.survives(org, world)
+
+
+def test_hazard_kills_and_frees_the_cell(config: Settings) -> None:
+    """A caught organism must stop acting and stop blocking the cell it held."""
+    hazard = Hazard()
+    world = World(config=config, objective=hazard, n_organisms=1)
+    org = world.organisms[0]
+
+    hazard.begin_generation(world)
+    world.relocate(org, int(hazard.x), int(hazard.y))
+    hazard.advance(world)
+
+    assert not org.alive
+    assert not world.is_occupied(org.x, org.y), "a dead organism still blocks its cell"
+    assert org not in world.living()
+    assert not hazard.survives(org, world)
+
+
+def test_dead_organisms_stop_moving(config: Settings) -> None:
+    """The update loop must skip the dead rather than quietly animating corpses."""
+    world = World(config=config)
+    victim = world.organisms[0]
+    world.kill(victim)
+    where = (victim.x, victim.y)
+
+    for _ in range(20):
+        world.update_organisms()
+
+    assert (victim.x, victim.y) == where
 
 
 def test_a_child_inherits_its_parents_wiring(config: Settings) -> None:
@@ -284,7 +544,7 @@ def test_evolution_improves_survival() -> None:
     every other test here would happily pass through.
     """
     config = replace(Settings(), n_organisms=150, steps_per_generation=100)
-    world = World(config=config, criterion=CRITERIA["left"])
+    world = World(config=config, objective="left")
 
     first = world.run_generation()
     for _ in range(19):
@@ -292,3 +552,53 @@ def test_evolution_improves_survival() -> None:
 
     assert last > first, f"no improvement: started at {first}, ended at {last}"
     assert last / config.n_organisms > 0.6, f"only {last}/{config.n_organisms} survived"
+
+
+# ----------------------------------------------------------------------------
+# Saving, loading and drawing
+# ----------------------------------------------------------------------------
+
+
+def test_genome_survives_a_save_and_load(config: Settings, tmp_path: Path) -> None:
+    """A kept creature is worthless if reloading it changes its behaviour."""
+    original = brain_utils.random_genome(config)
+    path = inspect_utils.save_genome(original, config, tmp_path / "creature.json")
+    restored = inspect_utils.load_genome(path)
+
+    assert restored == original
+    assert Brain(restored, config).describe() == Brain(original, config).describe()
+
+
+def test_saved_genomes_are_written_by_name(config: Settings, tmp_path: Path) -> None:
+    """
+    Names, not enum values, so a file stays valid when new senses are added.
+
+    A genome saved by index would silently mean something different after
+    anyone inserted a sensor in the middle of the enum.
+    """
+    genome = (Gene(Source.SENSOR, Sensor.AGE, Sink.ACTION, Action.MOVE_X, 1.0),)
+    path = inspect_utils.save_genome(genome, config, tmp_path / "named.json")
+    text = path.read_text(encoding="utf-8")
+    assert "age" in text
+    assert "move_x" in text
+
+
+def test_a_genome_from_the_future_is_refused(config: Settings, tmp_path: Path) -> None:
+    """An unreadable file should say so rather than load as nonsense."""
+    path = tmp_path / "future.json"
+    path.write_text('{"version": 99, "genes": []}', encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported genome format"):
+        inspect_utils.load_genome(path)
+
+
+def test_brain_diagram_draws_without_a_display(config: Settings) -> None:
+    """The wiring diagram is only useful if it renders for any genome."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    brain = Brain(brain_utils.random_genome(config), config)
+    axes = inspect_utils.draw_brain(brain, config)
+    assert axes.get_title()
+    plt.close("all")


### PR DESCRIPTION
Follows #3. Makes the simulation worth playing with: creatures can perceive each other, the world has obstacles and a scent layer, objectives go beyond "stand here at the end", and evolved creatures can be kept and inspected.

The senses and objectives were both too thin to produce interesting behaviour. A creature could tell that it was crowded but not *which way* the crowd lay; nothing one creature did could be perceived by another; and all four objectives were the same problem wearing different geometry.

## Creatures can perceive each other

Senses go from 10 to 18.

| new sense | what it gives them |
| --- | --- |
| `neighbours_east`, `neighbours_north` | **signed, directional** — `+1` means every neighbour in range lies that way |
| `nearest_neighbour` | 1 when adjacent, 0 when alone, falling off in between |
| `blocked_left`, `blocked_right` | join `blocked_forward`, all relative to the current heading |
| `pheromone_here`, `pheromone_east`, `pheromone_north` | the scent layer, as a level plus a gradient pair |

The directional pair is the important one. `population_density` is a scalar, so flocking, following and fleeing were unreachable *in principle*, not merely unlikely — there was no input whose sign could distinguish "toward" from "away".

Actions gain **`emit_pheromone`**, the only channel through which one creature can change what another perceives, and `move_left` (a quarter-turn from the current heading). Scent decays every timestep, so trails fade unless maintained.

## Objectives can watch, and can change the world

`Objective` replaces the position-only criterion, with three optional hooks — `begin_generation`, `advance`, `observe` — alongside the required `survives`. Selection can now follow an organism through a whole generation and move things around while it runs.

| objective | rule |
| --- | --- |
| `stay`, `stay-centre` | spend at least half the generation in the zone — arriving late is worthless |
| `there-and-back`, `top-to-bottom` | touch one band, then finish in another |
| `hazard` | survive a roaming circle that kills on contact |

The two-phase objectives are the first that **cannot be solved by a fixed heading**. A creature has to change its mind partway through, which means routing `age` or a recurrent inner neuron into its movement.

`zones()` reports the regions worth drawing, so the animation illustrates any new objective without being taught about it.

## The world

`barriers.py` adds five layouts (`wall`, `slalom`, `pillars`, `funnel`, `none`). Solid cells block movement and register on the `blocked_*` senses, which turns "head west" from a complete solution into one that strands a creature in a dead end.

## Tools

`inspect_utils.py` saves and loads genomes as JSON and draws a brain as a wiring diagram (blue excites, orange inhibits, thickness follows weight). Genomes are keyed by sense and action **names**, so a saved file stays valid after new capabilities are added — saving by index would silently mean something different once anyone inserted a sensor mid-enum.

`execute.py` gains `--objective`, `--barriers`, `--compare a,b,c`, `--save-genome`, `--load-genome` and `--draw-brain`.

Save/load carries real behaviour across processes: a genome evolved against `stay`/`slalom`, reloaded into a fresh `left` run, scores 89.6% in its first generation.

## Two bugs the new tests caught

Both would have been invisible by eye.

- **The pheromone gradient could return `-1.0000000893`** — its sub-sums are `float32` while the divisor is not, so rounding pushed the ratio past 1 and a sensor silently broke its `[-1, 1]` contract.
- **`save_genome` rounded weights to six decimals**, so a reloaded creature was subtly *not* the one that had been kept.

## One objective built and then dropped

`corner-to-centre` never rose above two survivors, so I removed it rather than ship something that does not work.

The cause is structural and worth knowing: selection is all-or-nothing, so a conjunction of two small regions gives evolution **no gradient to climb**, and the extinction reseed discards progress every generation that produces zero survivors. `top-to-bottom` replaces it and evolves properly (1 → 31 of 150 over 24 generations).

Partial-credit selection is the real fix and is a larger change than this PR. It is documented under "Known limits" in the README, along with reproduction still being asexual.

## Testing

59 checks, up from 27, covering barrier placement and blocking, sensor range under every layout, gradient *direction* (a mirrored world would be very hard to spot by eye), pheromone decay and saturation, hazard kills freeing their cell, each objective's semantics, and the genome round-trip. Every objective is parametrized over so a new one cannot be added without being exercised.
