### PR TITLE
Add metabolism, population dynamics, sexual reproduction and gene expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,35 @@ browser with no front-end change.
 ## How it works
 
 A generation runs for a fixed number of timesteps. At the end, an **objective**
-decides who reproduces. Survivors are cloned with mutation until the population
-is full again, the grid is cleared, and the next generation starts.
+decides who reproduces. Survivors leave offspring, the grid is cleared, and the
+next generation starts — with however many creatures were earned.
+
+## Staying alive is meant to be hard
+
+Three things push back, and together they make the population walk an edge
+rather than settle:
+
+**Metabolism.** Creatures burn energy: a base cost each timestep, more when
+they move, and — the important one — upkeep for *every distinct sense the brain
+is wired to*. A creature reading twelve senses pays for twelve senses whether
+or not they earn their keep, so more capability stops being strictly better.
+At the default cost a population sheds roughly two of its nine wired senses
+over thirty generations. Run out of energy and you starve mid-generation.
+
+**A population that can die.** Nothing is refilled to a fixed size. Each
+breeding survivor leaves `offspring_per_survivor` young, capped by the carrying
+capacity. At the default of 2.0 the population holds steady at *exactly* 50%
+survival — so that line, drawn on the survival chart, is the edge. Below it the
+population shrinks, and it can reach zero, which ends the run.
+
+**A shrinking target.** Optionally the survival zone contracts each generation,
+so a solution that worked at generation 10 stops working by 50. Worth knowing:
+this ratchets the early climb hard, but a population already at carrying
+capacity tends to absorb it.
+
+The defaults are deliberately mean. A measured run fell from 250 creatures to
+18 before recovering; under sexual reproduction, seeds exist that die out
+entirely in three generations.
 
 Each organism has a **genome**: a fixed-length tuple of genes, where every gene
 is one connection.
@@ -107,6 +134,40 @@ objectives are the first that cannot be solved by a fixed heading — a creature
 has to change its mind partway through, which means routing `age` or a
 recurrent inner neuron into its movement.
 
+## Reproduction
+
+`--reproduction asexual|sexual`, or the dropdown in the UI.
+
+**Asexual** clones a survivor with mutation. Any survivor breeds, wherever it
+ended up, and mutation is the only source of new variation.
+
+**Sexual** makes survivors *find each other*. Two survivors within
+`mating_radius` pair up — greedily and monogamously, nearest first — and their
+genomes cross over uniformly, every connection coming from one parent or the
+other. A survivor with nobody in range leaves nothing at all.
+
+That second clause is the whole point: reaching the zone stops being enough,
+because arriving alone is the same as not arriving. It puts real pressure on
+the neighbour senses, and it is much harsher — the same seed that cruises
+asexually can crash to a handful of creatures, or die out.
+
+Each child takes one parent's lineage at random, so a line can vanish even
+while its genes survive in somebody else's descendants.
+
+## Watching the population
+
+Reading one brain tells you what one creature does. The **gene expression**
+view tells you what evolution has decided: for every sense and action, the
+share of the population that wires it at all.
+
+It is the most informative thing in the UI. A sense at 100% has become
+load-bearing; one that falls to 0% has been actively selected away. In one
+measured run against the `left` objective, `x_position` went to 100% while
+`y_position` and `population_density` were driven to zero — and 200 founding
+lineages collapsed to 2.
+
+`--stats` prints the same picture in the terminal.
+
 ## Obstacles
 
 `--barriers none|wall|slalom|pillars|funnel`. Barriers are solid cells that
@@ -117,10 +178,12 @@ from a complete solution into one that strands a creature in a dead end.
 
 ```bash
 uv run python execute.py --objective stay --barriers slalom
-uv run python execute.py --compare left,stay,corners,hazard   # race them, headless
-uv run python execute.py --objective hazard --watch 1         # watch things die
-uv run python execute.py --watch 0                            # numbers only, fastest
-uv run python execute.py --seed 42                            # repeatable run
+uv run python execute.py --reproduction sexual --stats   # mates must be found
+uv run python execute.py --zone-shrink 0.02              # ratchet the difficulty
+uv run python execute.py --no-metabolism                 # brains cost nothing
+uv run python execute.py --compare left,stay,corners     # race them, headless
+uv run python execute.py --watch 0                       # numbers only, fastest
+uv run python execute.py --seed 42                       # repeatable run
 ```
 
 Keep a creature you like, and start a later run from it:
@@ -165,20 +228,22 @@ world = World(config=config, objective="there-and-back")
 | `capability_utils.py` | the `Sensor` and `Action` enums — what a creature can perceive and do |
 | `brain_utils.py` | genes, mutation, and the network a genome builds |
 | `organism.py` | `Organism`, `World`, the grid layers, and the generational cycle |
-| `objectives.py` | what it takes to reproduce |
+| `objectives.py` | what it takes to earn the right to reproduce |
+| `reproduction.py` | asexual and sexual strategies, and population dynamics |
+| `population_stats.py` | gene expression and lineages across the whole population |
 | `barriers.py` | obstacle layouts |
 | `inspect_utils.py` | saving, loading and drawing creatures |
 | `execute.py` | the terminal runner, live animation and comparison mode |
 | `server.py` | the web UI's backend, streaming runs over a websocket |
 | `static/` | the browser front end |
-| `test_simulation.py`, `test_server.py` | invariant checks — run `uv run pytest` |
+| `test_simulation.py`, `test_evolution.py`, `test_server.py` | invariant checks — run `uv run pytest` |
 | `sandbox.ipynb` | design notes and a scratchpad for poking at individual creatures |
 
 ## Development
 
 ```bash
 uv sync                 # create the environment
-uv run pytest           # 90 invariant checks
+uv run pytest           # 125 invariant checks
 uv run ruff check .     # lint
 uv run ruff format .    # format
 ```
@@ -187,12 +252,16 @@ uv run ruff format .    # format
 
 ## Known limits
 
-Reproduction is asexual — mutation is the only source of variation, with no
-crossover between survivors.
-
 Selection is all-or-nothing: an objective either passes a creature or does not,
 with no partial credit. Objectives that almost nobody can satisfy early on
 therefore have no gradient to climb, and the population reseeds from random
 genomes whenever a generation produces zero survivors. Conjunctive goals need
 their two halves chosen so that some creatures get there by luck in the first
 few generations.
+
+Mutation is still only point mutation. Genomes cannot grow, shrink, or
+duplicate a gene, so brain size is fixed for a whole run.
+
+The shrinking zone ratchets the early climb but does not destabilise a
+population that has already reached carrying capacity — measured over 100
+generations, a zone contracting from 12% to 4.4% did not dent it.

--- a/capability_utils.py
+++ b/capability_utils.py
@@ -49,8 +49,9 @@ class Sensor(IntEnum):
     LAST_MOVE_X = 13
     LAST_MOVE_Y = 14
     AGE = 15
-    RANDOM = 16
-    BIAS = 17
+    ENERGY = 16
+    RANDOM = 17
+    BIAS = 18
 
     def __str__(self) -> str:
         return self.name.lower()
@@ -210,6 +211,13 @@ def sense_age(org: Organism, world: World) -> float:
     return org.age / world.config.steps_per_generation
 
 
+def sense_energy(org: Organism, world: World) -> float:
+    """How full the tank is: 1 at the start of a generation, 0 at starvation."""
+    if org.config.initial_energy <= 0:
+        return 0.0
+    return max(0.0, min(1.0, org.energy / org.config.initial_energy))
+
+
 def sense_random(org: Organism, world: World) -> float:
     """Noise, so evolution has a source of unpredictability to draw on."""
     return random.uniform(-1.0, 1.0)
@@ -237,6 +245,7 @@ SENSOR_FUNCTIONS: Final[dict[Sensor, SensorFn]] = {
     Sensor.LAST_MOVE_X: sense_last_move_x,
     Sensor.LAST_MOVE_Y: sense_last_move_y,
     Sensor.AGE: sense_age,
+    Sensor.ENERGY: sense_energy,
     Sensor.RANDOM: sense_random,
     Sensor.BIAS: sense_bias,
 }

--- a/execute.py
+++ b/execute.py
@@ -23,6 +23,8 @@ import numpy as np
 
 import barriers
 import inspect_utils
+import population_stats
+import reproduction
 from objectives import OBJECTIVES
 from organism import Organism, World
 from settings import Settings
@@ -49,6 +51,29 @@ def parse_args() -> argparse.Namespace:
         choices=sorted(barriers.LAYOUTS),
         default=defaults.barrier_layout,
         help="obstacle layout built into the world",
+    )
+    parser.add_argument(
+        "--reproduction",
+        choices=list(reproduction.STRATEGIES),
+        default=defaults.reproduction,
+        help="asexual clones survivors; sexual pairs nearby survivors and crosses their genomes",
+    )
+    parser.add_argument(
+        "--no-metabolism",
+        action="store_true",
+        help="switch off energy, so brains cost nothing to run and nobody starves",
+    )
+    parser.add_argument(
+        "--zone-shrink",
+        type=float,
+        default=defaults.zone_shrink_per_generation,
+        metavar="F",
+        help="fraction the survival zone contracts by each generation",
+    )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="print how the population's genes are being expressed at the end",
     )
     parser.add_argument("--generations", type=int, default=defaults.n_generations)
     parser.add_argument("--population", type=int, default=defaults.n_organisms)
@@ -104,6 +129,9 @@ def build_config(args: argparse.Namespace) -> Settings:
         steps_per_generation=args.steps,
         n_generations=args.generations,
         barrier_layout=args.barriers,
+        reproduction=args.reproduction,
+        energy_enabled=not args.no_metabolism,
+        zone_shrink_per_generation=args.zone_shrink,
     )
 
 
@@ -207,24 +235,30 @@ def run(args: argparse.Namespace) -> World:
     title = args.objective if args.barriers == "none" else f"{args.objective} / {args.barriers}"
     animator = Animator(world, title) if args.watch else None
 
+    metabolism = "metabolism off" if args.no_metabolism else "metabolism on"
     print(
         f"{config.n_organisms} organisms, {config.steps_per_generation} steps per generation, "
-        f'"{args.objective}" objective, "{args.barriers}" barriers'
+        f'"{args.objective}" objective, "{args.barriers}" barriers, '
+        f"{args.reproduction} reproduction, {metabolism}"
     )
 
     started = time.monotonic()
     try:
         for generation in range(config.n_generations):
             animating = animator is not None and generation % args.watch == 0
+            before = world.population
             survivors = world.run_generation(on_step=animator.draw if animating else None)
 
-            share = survivors / config.n_organisms
+            share = survivors / max(before, 1)
             elapsed = time.monotonic() - started
             print(
                 f"generation {generation:>4}   "
-                f"survivors {survivors:>4} / {config.n_organisms:<4} ({share:6.1%})   "
-                f"{elapsed:6.1f}s"
+                f"survivors {survivors:>4} / {before:<4} ({share:6.1%})   "
+                f"next pop {world.population:>4}   {elapsed:6.1f}s"
             )
+            if world.extinct:
+                print("\nextinct: nobody left to breed.")
+                break
     except KeyboardInterrupt:
         print("\nstopped early")
     finally:
@@ -265,6 +299,10 @@ def report(world: World, args: argparse.Namespace) -> None:
     """Print, save and optionally draw one creature from the final generation."""
     if not world.organisms:
         return
+
+    if args.stats:
+        print("\nhow the population's genes are being expressed:")
+        print(population_stats.summarise(world))
 
     example = world.organisms[0]
     consulted = ", ".join(str(s) for s in example.brain.needed_sensors) or "none"

--- a/objectives.py
+++ b/objectives.py
@@ -54,17 +54,17 @@ class Shading:
 
 def left_edge(x: int, y: int, world: World) -> bool:
     """A band along the west wall."""
-    return x < world.width * world.config.survival_zone_fraction
+    return x < world.width * world.zone_fraction
 
 
 def right_edge(x: int, y: int, world: World) -> bool:
     """A band along the east wall."""
-    return x >= world.width * (1 - world.config.survival_zone_fraction)
+    return x >= world.width * (1 - world.zone_fraction)
 
 
 def centre(x: int, y: int, world: World) -> bool:
     """A circle at the middle of the world."""
-    radius = world.width * world.config.survival_zone_fraction
+    radius = world.width * world.zone_fraction
     dx = x - world.width / 2
     dy = y - world.height / 2
     return dx * dx + dy * dy <= radius * radius
@@ -72,17 +72,17 @@ def centre(x: int, y: int, world: World) -> bool:
 
 def top_edge(x: int, y: int, world: World) -> bool:
     """A band along the north wall."""
-    return y >= world.height * (1 - world.config.survival_zone_fraction)
+    return y >= world.height * (1 - world.zone_fraction)
 
 
 def bottom_edge(x: int, y: int, world: World) -> bool:
     """A band along the south wall."""
-    return y < world.height * world.config.survival_zone_fraction
+    return y < world.height * world.zone_fraction
 
 
 def corners(x: int, y: int, world: World) -> bool:
     """All four corners."""
-    span = world.width * world.config.survival_zone_fraction
+    span = world.width * world.zone_fraction
     near_x = x < span or x >= world.width - span
     near_y = y < span or y >= world.height - span
     return near_x and near_y

--- a/organism.py
+++ b/organism.py
@@ -25,6 +25,7 @@ import numpy as np
 
 import barriers as barrier_layouts
 import brain_utils
+import reproduction
 import settings
 from capability_utils import Action, Sensor, read_sensors
 from objectives import OBJECTIVES, Objective
@@ -59,11 +60,14 @@ class Organism:
         "alive",
         "brain",
         "config",
+        "energy",
         "genome",
         "last_dx",
         "last_dy",
+        "lineage",
         "name",
         "progress",
+        "upkeep",
         "x",
         "y",
     )
@@ -87,6 +91,15 @@ class Organism:
         self.last_dy = 0
         self.age = 0
         self.alive = True
+        self.energy = config.initial_energy
+
+        self.lineage: int = -1
+        """Which founding organism this one descends from. Set by the world."""
+
+        # What this brain costs to run, every timestep, for as long as it lives.
+        # Charged per *distinct sense consulted* rather than per gene, so wiring
+        # the same sense twice is free but reaching for a new one is not.
+        self.upkeep = config.metabolism + config.sense_cost * len(self.brain.needed_sensors)
 
         self.progress: dict[str, float] = {}
         """Scratch space for objectives that accumulate history over a generation."""
@@ -142,11 +155,22 @@ class Organism:
         urge_x *= 1.0 - stillness
         urge_y *= 1.0 - stillness
 
+        spent = self.upkeep
         if (emission := levels[Action.EMIT_PHEROMONE]) > 0:
             world.deposit_pheromone(self.x, self.y, emission * self.config.pheromone_deposit)
+            spent += emission * self.config.emit_cost
 
+        before = (self.x, self.y)
         self.move(_urge_to_step(urge_x), _urge_to_step(urge_y), world)
+        if (self.x, self.y) != before:
+            spent += self.config.move_cost
+
         self.age += 1
+
+        if self.config.energy_enabled:
+            self.energy -= spent
+            if self.energy <= 0.0:
+                world.kill(self)
 
     def move(self, dx: int, dy: int, world: World) -> None:
         """
@@ -176,12 +200,15 @@ class Organism:
 
     def reproduce(self) -> Organism:
         """
-        Produce one offspring: this organism's genome, copied with mutations.
+        Produce one offspring by cloning this organism's genome with mutations.
 
-        Reproduction is asexual, so all new variation comes from mutation. The
-        child is unplaced -- the world decides where it starts.
+        Kept for the asexual case and for direct use; `reproduction.py` owns
+        the general question of who breeds with whom. The child is unplaced --
+        the world decides where it starts.
         """
-        return Organism(self.config, genome=brain_utils.mutate(self.genome, self.config))
+        child = Organism(self.config, genome=brain_utils.mutate(self.genome, self.config))
+        child.lineage = self.lineage
+        return child
 
     def __repr__(self) -> str:
         state = "" if self.alive else ", dead"
@@ -221,10 +248,15 @@ class World:
         config: Settings | None = None,
         objective: Objective | str | None = None,
         n_organisms: int | None = None,
+        strategy: reproduction.Strategy | str | None = None,
     ) -> None:
         self.config = config or settings.DEFAULT
         self.objective = _resolve_objective(objective)
+        self.strategy = reproduction.resolve(strategy or self.config.reproduction)
         self.n_organisms = n_organisms if n_organisms is not None else self.config.n_organisms
+
+        self.extinct = False
+        """Set when a generation leaves nobody able to breed. The run is over."""
 
         self.width = self.config.width
         self.height = self.config.height
@@ -249,8 +281,29 @@ class World:
     def build_initial_config(self) -> list[Organism]:
         """Create the founding population, each with a fully random genome."""
         organisms = [Organism(self.config) for _ in range(self.n_organisms)]
+        # Every founder starts its own line, so later on it can be asked how
+        # many of them still have descendants.
+        for line, org in enumerate(organisms):
+            org.lineage = line
         self.reset_grid(organisms)
         return organisms
+
+    @property
+    def population(self) -> int:
+        """How many organisms there currently are, living or not."""
+        return len(self.organisms)
+
+    @property
+    def zone_fraction(self) -> float:
+        """
+        How big the survival zone is right now.
+
+        Contracts by `zone_shrink_per_generation` each generation, so a
+        solution that worked early stops working later, down to a floor that
+        keeps the target from vanishing entirely.
+        """
+        shrink = (1.0 - self.config.zone_shrink_per_generation) ** self.generation
+        return max(self.config.min_zone_fraction, self.config.survival_zone_fraction * shrink)
 
     def reset_grid(self, organisms: Iterable[Organism]) -> None:
         """Clear the grid and scatter the given organisms over empty cells."""
@@ -262,6 +315,7 @@ class World:
             org.last_dx = org.last_dy = 0
             org.age = 0
             org.alive = True
+            org.energy = self.config.initial_energy
             org.progress.clear()
             org.brain.reset()
             self.place(org, *self.random_empty_cell())
@@ -435,6 +489,9 @@ class World:
         Selection and repopulation happen when the generator finishes, so an
         abandoned generator leaves the world mid-generation and unchanged.
         """
+        if self.extinct:
+            return 0
+
         self.objective.begin_generation(self)
 
         for step in range(self.config.steps_per_generation):
@@ -474,16 +531,24 @@ class World:
 
     def reproduce_organisms(self, survivors: list[Organism]) -> None:
         """
-        Refill the population from the survivors and reset the grid.
+        Build the next generation from the survivors and reset the grid.
 
-        Parents are drawn at random with replacement, so a lone survivor can
-        found an entire generation. With no survivors at all the run would end,
-        so the world reseeds itself with fresh random genomes instead.
+        The population is earned rather than refilled: it grows when the
+        generation went well and shrinks when it did not. If nobody survives --
+        or, under sexual reproduction, nobody found a partner -- the population
+        is gone and the run is over.
         """
-        if survivors:
-            children = [random.choice(survivors).reproduce() for _ in range(self.n_organisms)]
-        else:
-            children = [Organism(self.config) for _ in range(self.n_organisms)]
+        children = reproduction.next_generation(survivors, self.strategy, self.config)
+        if not children:
+            self.extinct = True
+            self.organisms = []
+            self.occupancy[:, :] = False
+            return
+
+        # More offspring than open cells would loop forever looking for room.
+        room = int((~self.barriers).sum())
+        if len(children) > room:
+            children = children[:room]
 
         self.organisms = children
         self.reset_grid(children)

--- a/population_stats.py
+++ b/population_stats.py
@@ -1,0 +1,182 @@
+"""
+What the population as a whole looks like, rather than one creature at a time.
+
+Reading a single brain tells you what one creature does. Reading the whole
+population tells you what evolution has *decided* -- which senses it kept, which
+it abandoned, how much of the gene pool one founding line has taken over.
+
+`expression` is the summary the UI charts and the terminal prints. It is
+deliberately cheap: one pass over the genomes, once per generation.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+
+from brain_utils import Sink, Source
+from capability_utils import Action, Sensor
+
+if TYPE_CHECKING:
+    from organism import Organism, World
+
+
+def expression(world: World) -> dict[str, Any]:
+    """
+    A snapshot of how the population's genes are being expressed.
+
+    For each capability: what share of the population wires it at all, how many
+    connections the average creature devotes to it, and how strong those
+    connections are. Share is the interesting one -- a sense that drops to zero
+    has been actively selected away, and one that climbs to 1.0 has become
+    load-bearing.
+    """
+    organisms = world.organisms
+    if not organisms:
+        return _empty()
+
+    total = len(organisms)
+    sensor_users: Counter[Sensor] = Counter()
+    sensor_links: Counter[Sensor] = Counter()
+    sensor_weight: Counter[Sensor] = Counter()
+    action_users: Counter[Action] = Counter()
+    action_links: Counter[Action] = Counter()
+    action_weight: Counter[Action] = Counter()
+
+    senses_used = 0
+    for org in organisms:
+        seen_sensors: set[Sensor] = set()
+        seen_actions: set[Action] = set()
+        for gene in org.genome:
+            if gene.source_kind is Source.SENSOR:
+                sensor = Sensor(gene.source_id)
+                seen_sensors.add(sensor)
+                sensor_links[sensor] += 1
+                sensor_weight[sensor] += abs(gene.weight)
+            if gene.sink_kind is Sink.ACTION:
+                action = Action(gene.sink_id)
+                seen_actions.add(action)
+                action_links[action] += 1
+                action_weight[action] += abs(gene.weight)
+
+        sensor_users.update(seen_sensors)
+        action_users.update(seen_actions)
+        senses_used += len(seen_sensors)
+
+    return {
+        "population": total,
+        "sensors": [
+            _entry(
+                str(sensor),
+                sensor_users[sensor],
+                sensor_links[sensor],
+                sensor_weight[sensor],
+                total,
+            )
+            for sensor in Sensor
+        ],
+        "actions": [
+            _entry(
+                str(action),
+                action_users[action],
+                action_links[action],
+                action_weight[action],
+                total,
+            )
+            for action in Action
+        ],
+        "mean_senses_used": senses_used / total,
+        "mean_upkeep": sum(org.upkeep for org in organisms) / total,
+        "lineages": lineages(world),
+        "energy": energy_spread(world),
+    }
+
+
+def _entry(label: str, users: int, links: int, weight: float, total: int) -> dict[str, Any]:
+    return {
+        "label": label,
+        "share": users / total,
+        "links_per_organism": links / total,
+        "mean_weight": weight / links if links else 0.0,
+    }
+
+
+def lineages(world: World) -> dict[str, Any]:
+    """
+    How much of the population each founding line still accounts for.
+
+    A run that collapses to one lineage has lost its variation, and will only
+    find anything new by mutation from then on.
+    """
+    counts = Counter(org.lineage for org in world.organisms)
+    if not counts:
+        return {"alive": 0, "dominant_share": 0.0, "top": []}
+
+    total = sum(counts.values())
+    return {
+        "alive": len(counts),
+        "dominant_share": counts.most_common(1)[0][1] / total,
+        "top": [{"lineage": line, "share": count / total} for line, count in counts.most_common(8)],
+    }
+
+
+def energy_spread(world: World) -> dict[str, float]:
+    """Where the population's energy ended up, as a rough sense of how close it ran."""
+    living = [org.energy for org in world.organisms if org.alive]
+    if not living:
+        return {"mean": 0.0, "lowest": 0.0, "highest": 0.0}
+    return {
+        "mean": sum(living) / len(living),
+        "lowest": min(living),
+        "highest": max(living),
+    }
+
+
+def _empty() -> dict[str, Any]:
+    return {
+        "population": 0,
+        "sensors": [_entry(str(s), 0, 0, 0.0, 1) for s in Sensor],
+        "actions": [_entry(str(a), 0, 0, 0.0, 1) for a in Action],
+        "mean_senses_used": 0.0,
+        "mean_upkeep": 0.0,
+        "lineages": {"alive": 0, "dominant_share": 0.0, "top": []},
+        "energy": {"mean": 0.0, "lowest": 0.0, "highest": 0.0},
+    }
+
+
+def summarise(world: World, width: int = 34) -> str:
+    """
+    The same picture as text, for the terminal runner.
+
+    Only the capabilities anybody still uses are listed: a population that has
+    abandoned two thirds of its senses should look like it has.
+    """
+    stats = expression(world)
+    lines = [
+        f"population {stats['population']}   "
+        f"lineages {stats['lineages']['alive']}   "
+        f"mean senses wired {stats['mean_senses_used']:.1f}"
+    ]
+
+    for kind in ("sensors", "actions"):
+        used = [item for item in stats[kind] if item["share"] > 0.0]
+        if not used:
+            continue
+        lines.append(f"\n{kind}:")
+        for item in sorted(used, key=lambda entry: -entry["share"]):
+            filled = round(item["share"] * width)
+            bar = "#" * filled + "." * (width - filled)
+            lines.append(f"  {item['label']:>20} {bar} {item['share']:5.0%}")
+
+    return "\n".join(lines)
+
+
+def organism_row(org: Organism) -> dict[str, Any]:
+    """One creature's headline numbers, for inspection."""
+    return {
+        "lineage": org.lineage,
+        "alive": org.alive,
+        "energy": org.energy,
+        "upkeep": org.upkeep,
+        "senses_wired": len(org.brain.needed_sensors),
+    }

--- a/reproduction.py
+++ b/reproduction.py
@@ -1,0 +1,186 @@
+"""
+How the survivors fill the next generation.
+
+Two strategies, and the difference between them is not just genetics:
+
+- **asexual** — a survivor is cloned with mutation. All new variation comes
+  from mutation, and any survivor breeds regardless of where it ended up.
+
+- **sexual** — survivors must *find each other*. Two survivors within
+  `mating_radius` pair up and their genomes cross over; a survivor with nobody
+  in range leaves no offspring at all. Reaching the zone is no longer enough,
+  which is what makes the neighbour senses worth wiring.
+
+Either way the population is no longer refilled to a fixed size. Each breeding
+survivor leaves `offspring_per_survivor` young, capped by the carrying
+capacity, so the population grows when the generation went well and shrinks
+when it did not -- and can reach zero, which ends the run.
+"""
+
+from __future__ import annotations
+
+import random
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Final
+
+import brain_utils
+
+if TYPE_CHECKING:
+    from brain_utils import Genome
+    from organism import Organism
+    from settings import Settings
+
+
+class Strategy(ABC):
+    """A way of turning this generation's survivors into the next generation."""
+
+    name: str = "strategy"
+
+    needs_partners: bool = False
+    """Whether a lone survivor is unable to breed."""
+
+    @abstractmethod
+    def breeding_pairs(self, survivors: list[Organism], config: Settings) -> list[Parents]:
+        """Who actually gets to breed, as a list of one or two parents."""
+
+    def offspring(self, parents: Parents, config: Settings) -> Organism:
+        """One child from a set of parents."""
+        from organism import Organism  # imported late: organism imports this module
+
+        genome = self.combine(parents, config)
+        child = Organism(config, genome=brain_utils.mutate(genome, config))
+        # A child belongs to one parent's line. With two parents that is a
+        # coin toss, which is what lets a lineage die out even while its genes
+        # live on in somebody else's descendants.
+        child.lineage = random.choice(parents).lineage
+        return child
+
+    @abstractmethod
+    def combine(self, parents: Parents, config: Settings) -> Genome:
+        """The genome a child inherits before mutation."""
+
+
+type Parents = list["Organism"]
+
+
+class Asexual(Strategy):
+    """Clone a survivor. Mutation is the only source of new variation."""
+
+    name = "asexual"
+
+    def breeding_pairs(self, survivors: list[Organism], config: Settings) -> list[Parents]:
+        return [[survivor] for survivor in survivors]
+
+    def combine(self, parents: Parents, config: Settings) -> Genome:
+        return parents[0].genome
+
+
+class Sexual(Strategy):
+    """
+    Pair survivors that ended the generation near each other, and cross their genomes.
+
+    Pairing is greedy and monogamous: each survivor takes the nearest unpaired
+    partner within range. Anyone left over does not breed, so a population that
+    scatters can meet the objective and still collapse.
+    """
+
+    name = "sexual"
+    needs_partners = True
+
+    def breeding_pairs(self, survivors: list[Organism], config: Settings) -> list[Parents]:
+        unpaired = list(survivors)
+        random.shuffle(unpaired)  # no positional advantage in who pairs first
+        taken: set[int] = set()
+        pairs: list[Parents] = []
+
+        for index, candidate in enumerate(unpaired):
+            if index in taken:
+                continue
+            partner = self._nearest_free(unpaired, index, taken, config.mating_radius)
+            if partner is None:
+                continue
+            taken.add(index)
+            taken.add(partner)
+            pairs.append([candidate, unpaired[partner]])
+
+        return pairs
+
+    @staticmethod
+    def _nearest_free(
+        survivors: list[Organism], index: int, taken: set[int], radius: int
+    ) -> int | None:
+        """Index of the closest unpaired survivor within range, if there is one."""
+        here = survivors[index]
+        best: int | None = None
+        best_distance = radius + 1
+
+        for other_index, other in enumerate(survivors):
+            if other_index == index or other_index in taken:
+                continue
+            distance = max(abs(other.x - here.x), abs(other.y - here.y))
+            if distance <= radius and distance < best_distance:
+                best, best_distance = other_index, distance
+
+        return best
+
+    def combine(self, parents: Parents, config: Settings) -> Genome:
+        """
+        Uniform crossover: every connection comes from one parent or the other.
+
+        Genes here are independent connections rather than a linked sequence,
+        so there is nothing for a single crossover point to preserve -- picking
+        per gene mixes the parents far more thoroughly.
+        """
+        mother, father = parents[0], parents[1]
+        return tuple(
+            random.choice((from_mother, from_father))
+            for from_mother, from_father in zip(mother.genome, father.genome, strict=True)
+        )
+
+
+STRATEGIES: Final[dict[str, Strategy]] = {
+    strategy.name: strategy for strategy in (Asexual(), Sexual())
+}
+
+
+def resolve(strategy: Strategy | str | None) -> Strategy:
+    """Accept a strategy, the name of one, or nothing at all."""
+    if strategy is None:
+        return STRATEGIES["asexual"]
+    if isinstance(strategy, str):
+        try:
+            return STRATEGIES[strategy]
+        except KeyError:
+            known = ", ".join(STRATEGIES)
+            raise ValueError(
+                f"unknown reproduction strategy {strategy!r}; try one of: {known}"
+            ) from None
+    return strategy
+
+
+def next_generation(
+    survivors: list[Organism], strategy: Strategy, config: Settings
+) -> list[Organism]:
+    """
+    Build the next generation, or an empty list if the population dies out.
+
+    The size is earned rather than fixed: breeding survivors leave
+    `offspring_per_survivor` young each, capped by the carrying capacity. The
+    fractional part is settled by a coin toss so that a rate of 2.5 really does
+    average two and a half rather than quietly rounding down every time.
+    """
+    if not survivors:
+        return []
+
+    pairs = strategy.breeding_pairs(survivors, config)
+    if not pairs:
+        return []
+
+    breeding = sum(len(pair) for pair in pairs)
+    exact = breeding * config.offspring_per_survivor
+    total = int(exact)
+    if random.random() < exact - total:
+        total += 1
+    total = min(total, config.carrying_capacity)
+
+    return [strategy.offspring(random.choice(pairs), config) for _ in range(total)]

--- a/server.py
+++ b/server.py
@@ -29,6 +29,8 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 import barriers
+import population_stats
+import reproduction
 from capability_utils import Action, Sensor
 from objectives import OBJECTIVES
 from organism import World
@@ -59,6 +61,7 @@ async def options() -> dict[str, Any]:
     return {
         "objectives": list(OBJECTIVES),
         "barriers": sorted(barriers.LAYOUTS),
+        "reproduction": list(reproduction.STRATEGIES),
         "sensors": [
             {"value": int(sensor), "label": str(sensor), "group": _sensor_group(sensor)}
             for sensor in Sensor
@@ -67,12 +70,21 @@ async def options() -> dict[str, Any]:
         "defaults": {
             "objective": "left",
             "barriers": defaults.barrier_layout,
+            "reproduction": defaults.reproduction,
             "population": defaults.n_organisms,
             "steps": defaults.steps_per_generation,
             "generations": defaults.n_generations,
             "mutation_rate": defaults.point_mutation_rate,
             "n_genes": defaults.n_genes,
             "n_inner_neurons": defaults.n_inner_neurons,
+            "energy_enabled": defaults.energy_enabled,
+            "initial_energy": defaults.initial_energy,
+            "sense_cost": defaults.sense_cost,
+            "survival_zone_fraction": defaults.survival_zone_fraction,
+            "zone_shrink": defaults.zone_shrink_per_generation,
+            "offspring_per_survivor": defaults.offspring_per_survivor,
+            "carrying_capacity": defaults.carrying_capacity,
+            "mating_radius": defaults.mating_radius,
         },
     }
 
@@ -122,6 +134,10 @@ def build_settings(payload: dict[str, Any]) -> Settings:
     if layout not in barriers.LAYOUTS:
         raise ValueError(f"unknown barrier layout {layout!r}")
 
+    strategy = payload.get("reproduction", defaults.reproduction)
+    if strategy not in reproduction.STRATEGIES:
+        raise ValueError(f"unknown reproduction strategy {strategy!r}")
+
     config = replace(
         defaults,
         n_organisms=_clamp_int(payload.get("population"), 2, 2000, defaults.n_organisms),
@@ -130,9 +146,27 @@ def build_settings(payload: dict[str, Any]) -> Settings:
         n_genes=_clamp_int(payload.get("n_genes"), 1, 200, defaults.n_genes),
         n_inner_neurons=_clamp_int(payload.get("n_inner_neurons"), 1, 32, 4),
         barrier_layout=layout,
+        reproduction=strategy,
         point_mutation_rate=_clamp_float(
             payload.get("mutation_rate"), 0.0, 1.0, defaults.point_mutation_rate
         ),
+        energy_enabled=bool(payload.get("energy_enabled", defaults.energy_enabled)),
+        initial_energy=_clamp_float(
+            payload.get("initial_energy"), 1.0, 10_000.0, defaults.initial_energy
+        ),
+        sense_cost=_clamp_float(payload.get("sense_cost"), 0.0, 5.0, defaults.sense_cost),
+        survival_zone_fraction=_clamp_float(
+            payload.get("survival_zone_fraction"), 0.01, 0.9, defaults.survival_zone_fraction
+        ),
+        zone_shrink_per_generation=_clamp_float(payload.get("zone_shrink"), 0.0, 0.5, 0.0),
+        offspring_per_survivor=_clamp_float(
+            payload.get("offspring_per_survivor"), 0.1, 20.0, defaults.offspring_per_survivor
+        ),
+        # Capped below the grid size, or a generation could have nowhere to stand.
+        carrying_capacity=_clamp_int(
+            payload.get("carrying_capacity"), 2, 5000, defaults.carrying_capacity
+        ),
+        mating_radius=_clamp_int(payload.get("mating_radius"), 1, 200, defaults.mating_radius),
     )
     return config.with_capabilities(sensors, actions)
 
@@ -177,6 +211,8 @@ def opening_frame(world: World, config: Settings) -> dict[str, Any]:
         "generations": config.n_generations,
         "steps": config.steps_per_generation,
         "population": config.n_organisms,
+        "capacity": config.carrying_capacity,
+        "reproduction": config.reproduction,
         "barriers": _mask_to_base64(world.barriers),
         "dynamic_zones": world.objective.dynamic,
         "zones": [
@@ -224,8 +260,10 @@ async def stream_run(websocket: WebSocket, payload: dict[str, Any]) -> None:
     # choppier run; the UI exposes it as a speed control.
     stride = _clamp_int(payload.get("stride"), 1, 200, 1)
     history: list[float] = []
+    populations: list[int] = []
 
     for _ in range(config.n_generations):
+        before = world.population
         generation = world.iter_generation()
         pending = 0
         while True:
@@ -243,20 +281,30 @@ async def stream_run(websocket: WebSocket, payload: dict[str, Any]) -> None:
                 # promptly rather than at the end of the generation.
                 await asyncio.sleep(0)
 
-        history.append(survivors / config.n_organisms)
+        history.append(survivors / max(before, 1))
+        populations.append(world.population)
         await websocket.send_json(
             {
                 "type": "generation",
                 "generation": world.generation,
                 "survivors": survivors,
-                "population": config.n_organisms,
+                "population": world.population,
+                "previous_population": before,
+                "capacity": config.carrying_capacity,
+                "zone_fraction": world.zone_fraction,
                 "history": history,
+                "populations": populations,
+                "expression": population_stats.expression(world),
                 "brain": world.organisms[0].brain.describe() if world.organisms else "",
             }
         )
         await asyncio.sleep(0)
 
-    await websocket.send_json({"type": "done"})
+        if world.extinct:
+            await websocket.send_json({"type": "done", "extinct": True})
+            return
+
+    await websocket.send_json({"type": "done", "extinct": False})
 
 
 @app.websocket("/ws")

--- a/settings.py
+++ b/settings.py
@@ -58,16 +58,97 @@ class Settings:
     max_weight: float = 4.0
     """Gene weights are drawn from, and clamped to, [-max_weight, max_weight]."""
 
-    # Reproduction
+    # --- Metabolism -------------------------------------------------------
+    #
+    # Energy is what stops more capability from being strictly better. A brain
+    # pays upkeep for every sense it is wired to, whether or not that sense is
+    # earning its keep, so a bloated genome starves before it reaches the zone.
+
+    energy_enabled: bool = True
+    """Whether organisms burn energy and can starve."""
+
+    initial_energy: float = 140.0
+    """
+    Energy an organism starts each generation with.
+
+    Set so a median random brain -- about nine distinct senses -- spends
+    roughly 108 of it over a full generation and lives, while the bloated tail
+    starves partway through. Lower it and generation zero is wiped out before
+    selection has anything to work with.
+    """
+
+    metabolism: float = 0.10
+    """Energy burned every timestep just by being alive."""
+
+    sense_cost: float = 0.04
+    """
+    Energy burned per timestep for each distinct sense a brain consults.
+
+    Tuned so the cost actually bites: at this rate a population sheds roughly
+    two of its nine wired senses over thirty generations, while at half of it
+    the pressure is lost in the noise.
+    """
+
+    move_cost: float = 0.08
+    """Extra energy burned on a timestep the organism actually moves."""
+
+    emit_cost: float = 0.30
+    """Energy burned laying down pheromone at full strength."""
+
+    # --- Reproduction -----------------------------------------------------
+
+    reproduction: str = "asexual"
+    """Which strategy fills the next generation. See `reproduction.STRATEGIES`."""
+
     point_mutation_rate: float = 0.02
     """Per-gene chance of a mutation when an offspring is produced."""
 
     weight_jitter: float = 0.4
     """Standard deviation of the nudge applied to a mutated weight."""
 
-    # Selection
-    survival_zone_fraction: float = 0.2
-    """Fraction of the world's width that the zone objectives treat as safe."""
+    offspring_per_survivor: float = 2.0
+    """
+    How many offspring each breeding survivor leaves.
+
+    This is the knife's edge. At 2.0 the population holds steady at exactly 50%
+    survival, grows above it and shrinks below -- so a population that slips
+    even slightly is on its way out.
+    """
+
+    carrying_capacity: int = 400
+    """Hard ceiling on population, however well the survivors do."""
+
+    mating_radius: int = 18
+    """
+    For sexual reproduction: how far apart two survivors can be and still pair.
+
+    A survivor with nobody in range does not breed at all, so sex adds a second
+    problem on top of the objective -- reach the zone *and* not be alone.
+    """
+
+    # --- Selection --------------------------------------------------------
+
+    survival_zone_fraction: float = 0.12
+    """
+    Fraction of the world's width that the zone objectives treat as safe.
+
+    Deliberately mean. At 0.2 a population sails past replacement within a few
+    generations and pins at the carrying capacity; at 0.12 it usually crashes
+    first -- one measured run fell from 250 to 18 before recovering -- which is
+    the knife's edge worth watching.
+    """
+
+    zone_shrink_per_generation: float = 0.0
+    """
+    Fraction the survival zone contracts by each generation.
+
+    At 0 the target never moves. Above it, a solution that worked at generation
+    10 stops working by generation 50, so the population has to keep adapting
+    rather than settling.
+    """
+
+    min_zone_fraction: float = 0.03
+    """Floor the shrinking zone will not contract past."""
 
     stay_fraction: float = 0.5
     """For `stay`: the fraction of the generation that must be spent in the zone."""

--- a/static/app.js
+++ b/static/app.js
@@ -34,21 +34,32 @@ async function init() {
 
   fillSelect(el("objective"), options.objectives, options.defaults.objective);
   fillSelect(el("barriers"), options.barriers, options.defaults.barriers);
+  fillSelect(el("reproduction"), options.reproduction, options.defaults.reproduction);
 
-  el("population").value = options.defaults.population;
-  el("steps").value = options.defaults.steps;
-  el("generations").value = options.defaults.generations;
-  el("n_genes").value = options.defaults.n_genes;
-  el("n_inner_neurons").value = options.defaults.n_inner_neurons;
-  el("mutation_rate").value = options.defaults.mutation_rate;
+  const numbers = [
+    "population", "steps", "generations", "n_genes", "n_inner_neurons",
+    "mutation_rate", "initial_energy", "sense_cost", "survival_zone_fraction",
+    "zone_shrink", "offspring_per_survivor", "carrying_capacity", "mating_radius",
+  ];
+  for (const name of numbers) {
+    const key = { zone_shrink: "zone_shrink" }[name] || name;
+    if (options.defaults[key] !== undefined) el(name).value = options.defaults[key];
+  }
+  el("energy_enabled").checked = options.defaults.energy_enabled;
 
   buildCapabilityList("sensors", options.sensors, true);
   buildCapabilityList("actions", options.actions, false);
 
   el("mutation_rate").addEventListener("input", showMutationRate);
   el("stride").addEventListener("input", showStride);
+  el("survival_zone_fraction").addEventListener("input", showZone);
+  el("zone_shrink").addEventListener("input", showShrink);
+  el("reproduction").addEventListener("change", showMatingField);
   showMutationRate();
   showStride();
+  showZone();
+  showShrink();
+  showMatingField();
 
   el("start").addEventListener("click", start);
   el("stop").addEventListener("click", stop);
@@ -172,6 +183,22 @@ function showStride() {
   el("stride_label").textContent = stride === 1 ? "(every step)" : `(${stride} steps per frame)`;
 }
 
+function showZone() {
+  el("zone_label").textContent = `(${Math.round(el("survival_zone_fraction").value * 100)}% of the world)`;
+}
+
+function showShrink() {
+  const shrink = Number(el("zone_shrink").value);
+  el("shrink_label").textContent =
+    shrink === 0 ? "(fixed target)" : `(${(shrink * 100).toFixed(1)}% smaller each generation)`;
+}
+
+// Mating radius only means anything when survivors have to find each other.
+function showMatingField() {
+  el("mating_radius_field").style.display =
+    el("reproduction").value === "sexual" ? "" : "none";
+}
+
 /* ------------------------------------------------------------- websocket */
 
 function connect() {
@@ -208,12 +235,21 @@ function start() {
       action: "start",
       objective: el("objective").value,
       barriers: el("barriers").value,
+      reproduction: el("reproduction").value,
       population: Number(el("population").value),
       steps: Number(el("steps").value),
       generations: Number(el("generations").value),
       n_genes: Number(el("n_genes").value),
       n_inner_neurons: Number(el("n_inner_neurons").value),
       mutation_rate: Number(el("mutation_rate").value),
+      energy_enabled: el("energy_enabled").checked,
+      initial_energy: Number(el("initial_energy").value),
+      sense_cost: Number(el("sense_cost").value),
+      survival_zone_fraction: Number(el("survival_zone_fraction").value),
+      zone_shrink: Number(el("zone_shrink").value),
+      offspring_per_survivor: Number(el("offspring_per_survivor").value),
+      carrying_capacity: Number(el("carrying_capacity").value),
+      mating_radius: Number(el("mating_radius").value),
       stride: Number(el("stride").value),
       seed: el("seed").value,
       sensors,
@@ -243,13 +279,20 @@ function handle(message) {
     case "generation":
       el("gen-value").textContent = message.generation;
       el("survivors-value").textContent =
-        `${message.survivors} / ${message.population}`;
+        `${message.survivors} / ${message.previous_population}`;
+      el("pop-value").textContent = message.population;
       el("brain").textContent = message.brain || "(no creatures)";
-      drawChart(message.history);
+      drawChart(message.history, message.populations, message.capacity);
+      drawExpression(message.expression, message.zone_fraction);
       break;
     case "done":
       setRunning(false);
-      setStatus("Finished.");
+      setStatus(
+        message.extinct
+          ? "Extinct — nobody left to breed."
+          : "Finished.",
+        Boolean(message.extinct),
+      );
       break;
     case "stopped":
       setRunning(false);
@@ -357,15 +400,18 @@ function resetChart() {
   chartCtx.clearRect(0, 0, chart.width, chart.height);
 }
 
-function drawChart(history) {
+function drawChart(history, populations, capacity) {
   const { width, height } = chart;
-  const pad = 22;
+  const pad = 26;
   chartCtx.clearRect(0, 0, width, height);
+
+  const plotHeight = height - pad * 1.5;
+  const toY = (fraction) => height - pad - fraction * plotHeight;
 
   chartCtx.strokeStyle = "#2c2f3d";
   chartCtx.lineWidth = 1;
   for (const fraction of [0, 0.5, 1]) {
-    const y = height - pad - fraction * (height - pad * 1.5);
+    const y = toY(fraction);
     chartCtx.beginPath();
     chartCtx.moveTo(pad, y);
     chartCtx.lineTo(width - 6, y);
@@ -375,19 +421,84 @@ function drawChart(history) {
     chartCtx.fillText(`${Math.round(fraction * 100)}%`, 2, y + 3);
   }
 
-  if (!history.length) return;
+  // The replacement line: survive at less than this and the population shrinks.
+  const replacement = 1 / Number(el("offspring_per_survivor").value || 2);
+  if (replacement > 0 && replacement <= 1) {
+    chartCtx.strokeStyle = "#7a5c2e";
+    chartCtx.setLineDash([4, 4]);
+    chartCtx.beginPath();
+    chartCtx.moveTo(pad, toY(replacement));
+    chartCtx.lineTo(width - 6, toY(replacement));
+    chartCtx.stroke();
+    chartCtx.setLineDash([]);
+  }
 
+  if (!history.length) return;
   const span = Math.max(history.length - 1, 1);
-  chartCtx.strokeStyle = "#6ea8fe";
-  chartCtx.lineWidth = 2;
-  chartCtx.beginPath();
-  history.forEach((value, index) => {
-    const x = pad + (index / span) * (width - pad - 6);
-    const y = height - pad - value * (height - pad * 1.5);
-    if (index === 0) chartCtx.moveTo(x, y);
-    else chartCtx.lineTo(x, y);
+
+  const line = (values, colour, scale) => {
+    chartCtx.strokeStyle = colour;
+    chartCtx.lineWidth = 2;
+    chartCtx.beginPath();
+    values.forEach((value, index) => {
+      const x = pad + (index / span) * (width - pad - 6);
+      const y = toY(Math.min(1, value * scale));
+      if (index === 0) chartCtx.moveTo(x, y);
+      else chartCtx.lineTo(x, y);
+    });
+    chartCtx.stroke();
+  };
+
+  if (populations && capacity) line(populations, "#4ec9a0", 1 / capacity);
+  line(history, "#6ea8fe", 1);
+}
+
+/*
+ * Gene expression: what share of the population wires each capability at all.
+ * A sense that falls to zero has been actively selected away; one that climbs
+ * to 100% has become load-bearing.
+ */
+function drawExpression(expression, zoneFraction) {
+  if (!expression) return;
+
+  renderBars(el("sensor-bars"), expression.sensors, "sensor");
+  renderBars(el("action-bars"), expression.actions, "action");
+
+  const lineages = expression.lineages;
+  el("lineage-value").textContent = lineages.alive;
+
+  el("expression-summary").textContent =
+    `${expression.population} creatures · ` +
+    `${expression.mean_senses_used.toFixed(1)} senses wired on average · ` +
+    `upkeep ${expression.mean_upkeep.toFixed(2)}/step · ` +
+    `${lineages.alive} lineages left, biggest holds ` +
+    `${Math.round(lineages.dominant_share * 100)}% · ` +
+    `zone ${(zoneFraction * 100).toFixed(1)}%`;
+}
+
+function renderBars(host, entries, kind) {
+  // Rebuild only when the set of labels changes; otherwise update in place so
+  // the CSS width transition animates instead of flickering.
+  if (host.children.length !== entries.length) {
+    host.innerHTML = "";
+    for (const entry of entries) {
+      const row = document.createElement("div");
+      row.className = `bar-row ${kind}`;
+      row.innerHTML =
+        `<span class="bar-label"></span>` +
+        `<span class="bar-track"><span class="bar-fill"></span></span>` +
+        `<span class="bar-value"></span>`;
+      host.append(row);
+    }
+  }
+
+  entries.forEach((entry, index) => {
+    const row = host.children[index];
+    row.classList.toggle("dropped", entry.share === 0);
+    row.querySelector(".bar-label").textContent = entry.label;
+    row.querySelector(".bar-fill").style.width = `${entry.share * 100}%`;
+    row.querySelector(".bar-value").textContent = `${Math.round(entry.share * 100)}%`;
   });
-  chartCtx.stroke();
 }
 
 /* ---------------------------------------------------------------- status */

--- a/static/index.html
+++ b/static/index.html
@@ -50,7 +50,56 @@
           </label>
         </div>
 
+        <h2>Pressure</h2>
+
+        <label>
+          Survival zone <span class="hint" id="zone_label"></span>
+          <input id="survival_zone_fraction" type="range" min="0.02" max="0.5" step="0.01" />
+        </label>
+
+        <label>
+          Zone shrink per generation <span class="hint" id="shrink_label"></span>
+          <input id="zone_shrink" type="range" min="0" max="0.05" step="0.002" />
+        </label>
+
+        <div class="row">
+          <label>
+            Offspring / survivor
+            <input id="offspring_per_survivor" type="number" min="0.1" max="20" step="0.1" />
+          </label>
+          <label>
+            Carrying capacity
+            <input id="carrying_capacity" type="number" min="2" max="5000" step="50" />
+          </label>
+        </div>
+
+        <label class="check standalone">
+          <input id="energy_enabled" type="checkbox" checked />
+          Metabolism — brains burn energy and can starve
+        </label>
+
+        <div class="row">
+          <label>
+            Starting energy
+            <input id="initial_energy" type="number" min="1" max="10000" step="10" />
+          </label>
+          <label>
+            Cost per sense
+            <input id="sense_cost" type="number" min="0" max="5" step="0.01" />
+          </label>
+        </div>
+
         <h2>The creatures</h2>
+
+        <label>
+          Reproduction
+          <select id="reproduction"></select>
+        </label>
+
+        <label id="mating_radius_field">
+          Mating radius <span class="hint">(sexual only)</span>
+          <input id="mating_radius" type="number" min="1" max="200" step="1" />
+        </label>
 
         <div class="row">
           <label>
@@ -117,8 +166,33 @@
           <div class="readout"><span id="gen-value">—</span><label>generation</label></div>
           <div class="readout"><span id="alive-value">—</span><label>alive</label></div>
           <div class="readout"><span id="survivors-value">—</span><label>last survivors</label></div>
+          <div class="readout"><span id="pop-value">—</span><label>population</label></div>
+          <div class="readout"><span id="lineage-value">—</span><label>lineages left</label></div>
         </div>
-        <canvas id="chart" width="600" height="140"></canvas>
+
+        <canvas id="chart" width="600" height="150"></canvas>
+        <p class="legend">
+          <span class="key survival"></span> share surviving
+          <span class="key population"></span> population vs capacity
+        </p>
+
+        <details class="expression" open>
+          <summary>Gene expression across the population</summary>
+          <p class="expression-note" id="expression-summary">
+            Run a generation to see what the population is keeping.
+          </p>
+          <div class="expression-grid">
+            <div>
+              <h3>Senses wired</h3>
+              <div id="sensor-bars" class="bars"></div>
+            </div>
+            <div>
+              <h3>Actions driven</h3>
+              <div id="action-bars" class="bars"></div>
+            </div>
+          </div>
+        </details>
+
         <details class="brain">
           <summary>Wiring of one creature from the last generation</summary>
           <pre id="brain">Run a generation to see a brain.</pre>

--- a/static/style.css
+++ b/static/style.css
@@ -308,6 +308,118 @@ input[type="range"] {
   letter-spacing: 0.07em;
 }
 
+/* Gene expression --------------------------------------------------------- */
+
+.check.standalone {
+  margin: 0.75rem 0;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--panel-edge);
+  border-radius: 6px;
+  font-size: 0.82rem;
+}
+
+.legend {
+  display: flex;
+  gap: 1rem;
+  margin: -0.25rem 0 0;
+  font-size: 0.72rem;
+  color: var(--ink-dim);
+}
+
+.key {
+  display: inline-block;
+  width: 14px;
+  height: 3px;
+  margin-right: 0.3rem;
+  vertical-align: middle;
+  border-radius: 2px;
+}
+
+.key.survival {
+  background: #6ea8fe;
+}
+
+.key.population {
+  background: #4ec9a0;
+}
+
+.expression summary,
+.brain summary {
+  color: var(--ink-dim);
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.expression-note {
+  margin: 0.6rem 0 0;
+  font-size: 0.78rem;
+  color: var(--ink-dim);
+}
+
+.expression-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 700px) {
+  .expression-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.expression-grid h3 {
+  margin: 0 0 0.4rem;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #6f7488;
+}
+
+.bars {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 8.5rem 1fr 2.6rem;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.72rem;
+  color: var(--ink-dim);
+}
+
+.bar-row.dropped {
+  opacity: 0.4;
+}
+
+.bar-track {
+  height: 9px;
+  background: var(--grid);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  background: linear-gradient(90deg, #3f6fb5, #6ea8fe);
+  transition: width 0.25s ease;
+}
+
+.bar-row.action .bar-fill {
+  background: linear-gradient(90deg, #b5622f, #f0955a);
+}
+
+.bar-value {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+
 .brain summary {
   color: var(--ink-dim);
   font-size: 0.82rem;

--- a/test_evolution.py
+++ b/test_evolution.py
@@ -1,0 +1,411 @@
+"""
+Checks for metabolism, population dynamics, reproduction and observation.
+
+These are the mechanics that decide whether a population lives or dies, so the
+invariants worth pinning are mostly about *pressure*: that cost is charged, that
+the population can genuinely collapse, and that a strategy which cannot find
+partners really does fail rather than quietly falling back to cloning.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+import population_stats
+import reproduction
+from brain_utils import Gene, Sink, Source
+from capability_utils import Action, Sensor
+from organism import Organism, World
+from reproduction import Asexual, Sexual
+from settings import Settings
+
+
+@pytest.fixture(autouse=True)
+def _deterministic() -> None:
+    random.seed(0)
+    np.random.seed(0)
+
+
+@pytest.fixture
+def config() -> Settings:
+    return replace(Settings(), n_organisms=40, steps_per_generation=30)
+
+
+def straight_line_genome() -> tuple[Gene, ...]:
+    """A minimal brain: one sense, one action, so upkeep is predictable."""
+    return (Gene(Source.SENSOR, Sensor.BIAS, Sink.ACTION, Action.MOVE_X, 4.0),)
+
+
+# ----------------------------------------------------------------------------
+# Metabolism
+# ----------------------------------------------------------------------------
+
+
+def test_upkeep_scales_with_distinct_senses_not_gene_count(config: Settings) -> None:
+    """
+    Wiring the same sense twice is free; reaching for a new one is not.
+
+    This is what makes the cost a pressure on *breadth* of perception rather
+    than a flat tax on genome size.
+    """
+    twice_the_same = Organism(
+        config,
+        genome=(
+            Gene(Source.SENSOR, Sensor.BIAS, Sink.ACTION, Action.MOVE_X, 1.0),
+            Gene(Source.SENSOR, Sensor.BIAS, Sink.ACTION, Action.MOVE_Y, 1.0),
+        ),
+    )
+    two_different = Organism(
+        config,
+        genome=(
+            Gene(Source.SENSOR, Sensor.BIAS, Sink.ACTION, Action.MOVE_X, 1.0),
+            Gene(Source.SENSOR, Sensor.AGE, Sink.ACTION, Action.MOVE_Y, 1.0),
+        ),
+    )
+    assert two_different.upkeep > twice_the_same.upkeep
+    assert twice_the_same.upkeep == pytest.approx(config.metabolism + config.sense_cost)
+
+
+def test_a_costly_brain_starves_before_a_lean_one(config: Settings) -> None:
+    """The whole point of metabolism: complexity has to earn its keep."""
+    lean = Organism(config, genome=straight_line_genome())
+    bloated = Organism(
+        config,
+        genome=tuple(
+            Gene(Source.SENSOR, sensor, Sink.ACTION, Action.MOVE_X, 1.0) for sensor in Sensor
+        ),
+    )
+    assert bloated.upkeep > lean.upkeep
+
+    world = World(config=config, n_organisms=1)
+    world.organisms = [lean, bloated]
+    world.reset_grid(world.organisms)
+    for _ in range(config.steps_per_generation):
+        world.update_organisms()
+    assert bloated.energy < lean.energy
+
+
+def test_starvation_kills_and_frees_the_cell(config: Settings) -> None:
+    """A starved organism must leave play properly, not linger as a blocker."""
+    starving = replace(config, initial_energy=0.5, metabolism=1.0)
+    world = World(config=starving, n_organisms=1)
+    org = world.organisms[0]
+    world.relocate(org, 40, 40)
+
+    org.act(world)
+    assert not org.alive
+    assert not world.is_occupied(40, 40)
+
+
+def test_metabolism_can_be_switched_off(config: Settings) -> None:
+    """With energy disabled nobody starves, however expensive the brain."""
+    free = replace(config, energy_enabled=False, initial_energy=0.1, metabolism=10.0)
+    world = World(config=free)
+    for _ in range(20):
+        world.update_organisms()
+    assert all(org.alive for org in world.organisms)
+
+
+def test_the_energy_sense_reports_the_tank(config: Settings) -> None:
+    world = World(config=config, n_organisms=1)
+    org = world.organisms[0]
+    assert org.perceive(world)[Sensor.ENERGY] == pytest.approx(1.0)
+
+    org.energy = config.initial_energy / 2
+    assert org.perceive(world)[Sensor.ENERGY] == pytest.approx(0.5)
+
+    org.energy = -5.0
+    assert org.perceive(world)[Sensor.ENERGY] == 0.0
+
+
+# ----------------------------------------------------------------------------
+# Population dynamics
+# ----------------------------------------------------------------------------
+
+
+def test_population_grows_and_shrinks_with_survival(config: Settings) -> None:
+    """
+    The knife's edge: `offspring_per_survivor` sets the replacement rate.
+
+    At 2.0, half the population surviving exactly replaces it -- so this is the
+    number that decides whether a run recovers or slides to extinction.
+    """
+    world = World(config=replace(config, offspring_per_survivor=2.0, carrying_capacity=1000))
+    survivors = world.organisms[:10]
+    world.reproduce_organisms(survivors)
+    assert world.population == 20
+
+
+def test_carrying_capacity_caps_a_boom(config: Settings) -> None:
+    world = World(config=replace(config, offspring_per_survivor=10.0, carrying_capacity=25))
+    world.reproduce_organisms(world.organisms[:20])
+    assert world.population == 25
+
+
+def test_no_survivors_means_extinction(config: Settings) -> None:
+    """
+    The population is no longer refilled from nowhere, so a wipe-out is final.
+
+    This replaces the old reseeding behaviour: a run that dies out has to say
+    so rather than quietly starting again with random genomes.
+    """
+    world = World(config=config)
+    world.reproduce_organisms([])
+
+    assert world.extinct
+    assert world.population == 0
+    assert int(world.occupancy.sum()) == 0
+    assert world.run_generation() == 0, "an extinct world should not keep running"
+
+
+def test_a_population_can_die_out_over_a_run() -> None:
+    """End to end: harsh enough conditions really do end a run."""
+    doomed = replace(
+        Settings(),
+        n_organisms=30,
+        steps_per_generation=40,
+        survival_zone_fraction=0.02,
+        offspring_per_survivor=1.0,
+    )
+    world = World(config=doomed, objective="left")
+    for _ in range(40):
+        world.run_generation()
+        if world.extinct:
+            break
+    assert world.extinct, "these conditions should not be survivable"
+
+
+# ----------------------------------------------------------------------------
+# The shrinking zone
+# ----------------------------------------------------------------------------
+
+
+def test_the_zone_contracts_as_generations_pass(config: Settings) -> None:
+    world = World(config=replace(config, zone_shrink_per_generation=0.05), objective="left")
+
+    start = world.zone_fraction
+    world.generation = 20
+    assert world.zone_fraction < start
+
+    zone = world.objective.zones(world)[0].mask.sum()
+    world.generation = 0
+    assert world.objective.zones(world)[0].mask.sum() > zone, "the drawn zone must shrink too"
+
+
+def test_the_zone_never_shrinks_past_its_floor(config: Settings) -> None:
+    """A target that vanishes entirely would make the run unwinnable by accident."""
+    world = World(config=replace(config, zone_shrink_per_generation=0.5))
+    world.generation = 500
+    assert world.zone_fraction == pytest.approx(config.min_zone_fraction)
+
+
+def test_a_fixed_zone_does_not_move(config: Settings) -> None:
+    world = World(config=replace(config, zone_shrink_per_generation=0.0))
+    before = world.zone_fraction
+    world.generation = 99
+    assert world.zone_fraction == before
+
+
+# ----------------------------------------------------------------------------
+# Reproduction
+# ----------------------------------------------------------------------------
+
+
+def test_asexual_offspring_are_mutated_clones(config: Settings) -> None:
+    quiet = replace(config, point_mutation_rate=0.0)
+    parent = Organism(quiet, genome=straight_line_genome())
+    child = Asexual().offspring([parent], quiet)
+    assert child.genome == parent.genome
+    assert child.lineage == parent.lineage
+
+
+def test_crossover_takes_every_gene_from_one_parent_or_the_other(config: Settings) -> None:
+    """A child must be a recombination of its parents, never an invention."""
+    quiet = replace(config, point_mutation_rate=0.0, n_genes=12)
+    mother = Organism(quiet)
+    father = Organism(quiet)
+
+    child_genome = Sexual().combine([mother, father], quiet)
+    assert len(child_genome) == len(mother.genome)
+    for index, gene in enumerate(child_genome):
+        assert gene in (mother.genome[index], father.genome[index])
+
+
+def test_crossover_actually_mixes_the_parents(config: Settings) -> None:
+    """Uniform crossover should draw from both sides, not copy one parent."""
+    quiet = replace(config, point_mutation_rate=0.0, n_genes=40)
+    mother, father = Organism(quiet), Organism(quiet)
+
+    from_father = 0
+    for _ in range(20):
+        child = Sexual().combine([mother, father], quiet)
+        from_father += sum(1 for index, gene in enumerate(child) if gene == father.genome[index])
+    share = from_father / (20 * 40)
+    assert 0.3 < share < 0.7, f"crossover looks lopsided: {share:.0%} from the father"
+
+
+def test_sexual_reproduction_needs_a_partner_in_range(config: Settings) -> None:
+    """
+    A survivor with nobody nearby leaves no offspring at all.
+
+    This is the whole point of the sexual strategy: reaching the zone is not
+    enough if you arrive alone.
+    """
+    close = replace(config, mating_radius=5)
+    world = World(config=close, n_organisms=2, strategy="sexual")
+    first, second = world.organisms
+
+    world.relocate(first, 5, 5)
+    world.relocate(second, 90, 90)
+    assert Sexual().breeding_pairs([first, second], close) == []
+
+    world.relocate(second, 8, 8)
+    assert len(Sexual().breeding_pairs([first, second], close)) == 1
+
+
+def test_a_lone_survivor_ends_a_sexual_run(config: Settings) -> None:
+    """One creature cannot repopulate the world on its own."""
+    world = World(config=config, strategy="sexual")
+    world.reproduce_organisms([world.organisms[0]])
+    assert world.extinct
+
+
+def test_a_lone_survivor_can_repopulate_an_asexual_run(config: Settings) -> None:
+    """The contrast that makes the sexual case meaningful."""
+    world = World(config=config, strategy="asexual")
+    world.reproduce_organisms([world.organisms[0]])
+    assert not world.extinct
+    assert world.population > 0
+
+
+def test_pairing_is_monogamous(config: Settings) -> None:
+    """Each survivor pairs at most once, so a crowd cannot all breed with one creature."""
+    world = World(config=config, n_organisms=6, strategy="sexual")
+    for org in world.organisms:
+        world.relocate(org, 50 + world.organisms.index(org), 50)
+
+    pairs = Sexual().breeding_pairs(world.organisms, config)
+    paired = [org for pair in pairs for org in pair]
+    assert len(paired) == len(set(map(id, paired))), "an organism bred twice"
+
+
+def test_unknown_strategy_is_reported_clearly() -> None:
+    with pytest.raises(ValueError, match="unknown reproduction strategy"):
+        reproduction.resolve("budding")
+
+
+@pytest.mark.parametrize("strategy", list(reproduction.STRATEGIES))
+def test_every_strategy_can_run_a_generation(strategy: str, config: Settings) -> None:
+    world = World(config=replace(config, n_organisms=80), objective="left", strategy=strategy)
+    world.run_generation()
+    assert world.extinct or world.population > 0
+
+
+# ----------------------------------------------------------------------------
+# Lineage
+# ----------------------------------------------------------------------------
+
+
+def test_founders_each_start_their_own_line(config: Settings) -> None:
+    world = World(config=config)
+    assert len({org.lineage for org in world.organisms}) == config.n_organisms
+
+
+def test_children_inherit_a_parent_line(config: Settings) -> None:
+    world = World(config=config, strategy="asexual")
+    parent = world.organisms[0]
+    world.reproduce_organisms([parent])
+    assert all(org.lineage == parent.lineage for org in world.organisms)
+
+
+def test_a_sexual_child_takes_one_parent_line(config: Settings) -> None:
+    """With two parents the line is a coin toss, never a new invented one."""
+    mother, father = Organism(config), Organism(config)
+    mother.lineage, father.lineage = 11, 22
+
+    lines = {Sexual().offspring([mother, father], config).lineage for _ in range(40)}
+    assert lines <= {11, 22}
+    assert len(lines) == 2, "one parent's line is never being passed on"
+
+
+def test_lineages_collapse_as_a_run_proceeds(config: Settings) -> None:
+    """
+    Selection should concentrate the gene pool, not preserve every founder.
+
+    Run under gentle conditions on purpose: the point is to watch lineages
+    narrow, which needs a population that survives long enough to do it.
+    """
+    gentle = replace(
+        config,
+        n_organisms=120,
+        energy_enabled=False,
+        survival_zone_fraction=0.25,
+    )
+    world = World(config=gentle, objective="left")
+    before = population_stats.lineages(world)["alive"]
+    assert before == 120, "founders should start as 120 separate lines"
+
+    for _ in range(6):
+        world.run_generation()
+    assert not world.extinct, "gentle conditions should not wipe the population out"
+    assert population_stats.lineages(world)["alive"] < before
+
+
+# ----------------------------------------------------------------------------
+# Observing the population
+# ----------------------------------------------------------------------------
+
+
+def test_expression_covers_every_capability(config: Settings) -> None:
+    """The chart needs a row per capability, including the ones nobody uses."""
+    world = World(config=config)
+    stats = population_stats.expression(world)
+
+    assert [item["label"] for item in stats["sensors"]] == [str(s) for s in Sensor]
+    assert [item["label"] for item in stats["actions"]] == [str(a) for a in Action]
+    for item in stats["sensors"] + stats["actions"]:
+        assert 0.0 <= item["share"] <= 1.0
+
+
+def test_expression_reports_what_the_population_actually_wires(config: Settings) -> None:
+    """A population wired to one sense must read as exactly that."""
+    world = World(config=config)
+    for org in world.organisms:
+        org.genome = straight_line_genome()
+        org.brain = type(org.brain)(org.genome, config)
+
+    stats = population_stats.expression(world)
+    shares = {item["label"]: item["share"] for item in stats["sensors"]}
+    assert shares["bias"] == 1.0
+    assert all(share == 0.0 for label, share in shares.items() if label != "bias")
+    assert stats["mean_senses_used"] == pytest.approx(1.0)
+
+
+def test_expression_survives_an_empty_population(config: Settings) -> None:
+    """An extinct run still has to render without blowing up the UI."""
+    world = World(config=config)
+    world.reproduce_organisms([])
+    stats = population_stats.expression(world)
+    assert stats["population"] == 0
+    assert len(stats["sensors"]) == len(Sensor)
+
+
+def test_disabled_capabilities_read_as_unused(config: Settings) -> None:
+    """The expression view should show a switched-off sense sitting at zero."""
+    limited = config.with_capabilities(sensors=[Sensor.BIAS], actions=[Action.MOVE_X])
+    world = World(config=limited)
+    stats = population_stats.expression(world)
+    shares = {item["label"]: item["share"] for item in stats["sensors"]}
+    assert shares["bias"] == 1.0
+    assert shares["pheromone_here"] == 0.0
+
+
+def test_the_text_summary_names_what_is_used(config: Settings) -> None:
+    world = World(config=config)
+    text = population_stats.summarise(world)
+    assert "population" in text
+    assert "lineages" in text

--- a/test_server.py
+++ b/test_server.py
@@ -19,6 +19,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import barriers
+import reproduction
 from capability_utils import Action, Sensor
 from objectives import OBJECTIVES
 from server import app, build_settings
@@ -42,6 +43,15 @@ def full_payload(**overrides: Any) -> dict[str, Any]:
         "n_genes": 8,
         "n_inner_neurons": 2,
         "mutation_rate": 0.02,
+        "reproduction": "asexual",
+        "energy_enabled": True,
+        "initial_energy": 140.0,
+        "sense_cost": 0.04,
+        "survival_zone_fraction": 0.12,
+        "zone_shrink": 0.0,
+        "offspring_per_survivor": 2.0,
+        "carrying_capacity": 400,
+        "mating_radius": 18,
         "stride": 1,
         "seed": 3,
         "sensors": [int(s) for s in Sensor],
@@ -70,6 +80,7 @@ def test_options_expose_every_capability(client: TestClient) -> None:
     assert [item["label"] for item in options["actions"]] == [str(a) for a in Action]
     assert options["objectives"] == list(OBJECTIVES)
     assert options["barriers"] == sorted(barriers.LAYOUTS)
+    assert options["reproduction"] == list(reproduction.STRATEGIES)
 
 
 def test_every_sensor_gets_a_menu_heading(client: TestClient) -> None:
@@ -262,6 +273,76 @@ def test_a_static_objective_does_not_resend_its_zones(client: TestClient) -> Non
 
         frame = socket.receive_json()
         assert "zones" not in frame
+
+
+def test_the_new_mechanics_reach_the_settings() -> None:
+    """Every control the UI grew has to actually change the run."""
+    config = build_settings(
+        full_payload(
+            reproduction="sexual",
+            energy_enabled=False,
+            initial_energy=55.0,
+            sense_cost=0.5,
+            zone_shrink=0.02,
+            offspring_per_survivor=3.5,
+            carrying_capacity=99,
+            mating_radius=42,
+        )
+    )
+    assert config.reproduction == "sexual"
+    assert config.energy_enabled is False
+    assert config.initial_energy == 55.0
+    assert config.sense_cost == 0.5
+    assert config.zone_shrink_per_generation == 0.02
+    assert config.offspring_per_survivor == 3.5
+    assert config.carrying_capacity == 99
+    assert config.mating_radius == 42
+
+
+def test_unknown_reproduction_strategy_is_refused() -> None:
+    with pytest.raises(ValueError, match="unknown reproduction strategy"):
+        build_settings(full_payload(reproduction="mitosis"))
+
+
+def test_a_generation_message_carries_the_population_picture(client: TestClient) -> None:
+    """The readouts and the gene-expression chart are all fed from this one message."""
+    with client.websocket_connect("/ws") as socket:
+        socket.send_json(full_payload(steps=3, generations=1, population=30))
+        socket.receive_json()
+
+        while (message := socket.receive_json())["type"] != "generation":
+            pass
+
+        assert message["previous_population"] == 30
+        assert message["capacity"] == 400
+        assert message["zone_fraction"] == pytest.approx(0.12)
+        assert len(message["populations"]) == 1
+
+        expression = message["expression"]
+        assert [item["label"] for item in expression["sensors"]] == [str(s) for s in Sensor]
+        assert [item["label"] for item in expression["actions"]] == [str(a) for a in Action]
+        assert expression["lineages"]["alive"] >= 1
+        assert expression["mean_senses_used"] > 0
+
+
+def test_an_extinct_run_says_so_and_stops(client: TestClient) -> None:
+    """A population that dies out must report it rather than looking finished."""
+    with client.websocket_connect("/ws") as socket:
+        socket.send_json(
+            full_payload(
+                steps=8,
+                generations=50,
+                population=20,
+                survival_zone_fraction=0.01,
+                offspring_per_survivor=0.5,
+                stride=50,
+            )
+        )
+        socket.receive_json()
+
+        while (message := socket.receive_json())["type"] != "done":
+            pass
+        assert message["extinct"] is True
 
 
 def test_stride_thins_the_frames(client: TestClient) -> None:

--- a/test_simulation.py
+++ b/test_simulation.py
@@ -410,20 +410,33 @@ def test_gene_describe_names_its_endpoints() -> None:
 # ----------------------------------------------------------------------------
 
 
-def test_a_generation_preserves_population_size(config: Settings) -> None:
-    """However selection goes, the next generation must be full and placed."""
+def test_a_new_generation_starts_clean(config: Settings) -> None:
+    """
+    However selection goes, whoever survives into the next generation is ready.
+
+    Population size is no longer fixed -- it is earned, and tested in
+    `test_evolution.py` -- but everyone alive must be placed and reset.
+    """
     world = World(config=config)
     for _ in range(3):
         world.run_generation()
-        assert len(world.organisms) == config.n_organisms
+        if world.extinct:
+            break
+        assert world.population <= config.carrying_capacity
         for org in world.organisms:
             assert org.placed, "organism was never placed"
             assert org.age == 0, "a new generation should start at age zero"
             assert org.alive, "a new generation should start alive"
+            assert org.energy == config.initial_energy, "energy should be refilled"
 
 
-def test_extinction_reseeds_rather_than_ending_the_run(config: Settings) -> None:
-    """With no survivors the world must refill itself instead of emptying."""
+def test_an_impossible_objective_ends_the_run(config: Settings) -> None:
+    """
+    With nobody able to breed, the population is gone and stays gone.
+
+    This used to reseed from fresh random genomes, which quietly hid the fact
+    that a run had failed. Extinction is now the honest outcome.
+    """
 
     class Impossible(objectives.Objective):
         name = "impossible"
@@ -433,7 +446,9 @@ def test_extinction_reseeds_rather_than_ending_the_run(config: Settings) -> None
 
     world = World(config=config, objective=Impossible())
     world.run_generation()
-    assert len(world.organisms) == config.n_organisms
+
+    assert world.extinct
+    assert world.organisms == []
 
 
 @pytest.mark.parametrize("name", list(OBJECTIVES))


### PR DESCRIPTION
Follows #5. Survival was never really in doubt: the population was refilled to a fixed size every generation whether it had earned it or not, extinction quietly reseeded from random genomes, and more capability was strictly better because nothing cost anything.

Four changes put the population back on an edge, and make it possible to watch what evolution actually decides.

## Metabolism — the edge depends on genes

Organisms carry energy and burn it: a base rate each timestep, more when they move or emit, and **upkeep for every distinct sense the brain consults**.

Charging per *distinct sense* rather than per gene is the point. Wiring the same sense twice is free; reaching for a new one is not. So the pressure falls on breadth of perception, and a creature reading twelve senses pays for twelve whether or not they earn their keep. Run out and you starve mid-generation. Adds an `energy` sense so they can feel it coming.

## Population dynamics — the knife's edge itself

Nothing is refilled. Each breeding survivor leaves `offspring_per_survivor` young, capped by a carrying capacity.

At the default of 2.0 the population holds steady at **exactly 50% survival** — so that line, drawn on the survival chart, is the edge. Above it the population grows, below it it slides toward zero. A wipe-out is now final and reported, replacing the old reseed that quietly hid failed runs.

## Sexual reproduction

Chosen by menu, alongside asexual.

Survivors must **find each other**: two within `mating_radius` pair up (greedily, monogamously, nearest first) and their genomes cross over uniformly, every connection coming from one parent or the other. A survivor with nobody in range leaves nothing at all.

That clause is what makes it thematic rather than cosmetic — reaching the zone stops being enough if you arrive alone, which is what finally puts the neighbour senses to work. It is much harsher: the same seed that cruises asexually can crash to a handful of creatures.

Children take one parent's lineage at random, so a line can vanish while its genes survive in somebody else's descendants.

## Observing the population

`population_stats.py` reports what the *whole population* is doing rather than one creature: the share of it wiring each sense and action, mean upkeep, and how many founding lineages survive. Rendered as bars in the browser, and by `--stats` in the terminal:

```
population 400   lineages 6   mean senses wired 7.3

                   age ##############################....   89%
                  bias ##############################....   87%
            y_position #############################.....   85%
       ...
          blocked_left #.................................    4%
                energy #.................................    4%
```

Also adds an optional shrinking survival zone (off by default) that contracts the target each generation down to a floor.

## Tuning is measured, not guessed

Every default here came from running the thing:

| knob | value | why |
| --- | --- | --- |
| `sense_cost` | 0.04 | a population sheds ~2 of its 9 wired senses over 30 generations; at 0.02 the effect is lost in the noise |
| `survival_zone_fraction` | 0.12 | produces a real crash before recovery (one run fell 250 → 18); at 0.2 it sails straight to capacity |
| `initial_energy` | 140 | a median random brain spends ~108 and lives while the bloated tail starves — **at 100 the whole of generation zero died** before selection had anything to work with, and sexual runs went extinct in two generations |
| `mating_radius` | 18 | at 8, scattered survivors in a 100-wide world almost never paired, so sexual runs died immediately |

## Verified in the browser

A sexual run against `left` drove `x_position` to 100% while `y_position` and `population_density` were **selected away to zero**, and 200 founding lineages collapsed to 2. Population fell to 20 and held. That is the observation feature and the pressure features demonstrating each other.

## Two things worth flagging

**The shrinking zone is weaker than it sounds.** Measured over 100 generations, a zone contracting from 12% to 4.4% did not dent a population already at carrying capacity. It ratchets the early climb hard but does not destabilise a solved run. Documented under "Known limits" rather than oversold.

**Two existing tests asserted the old behaviour** — fixed population size, and reseeding on extinction — and have been rewritten to the new contract rather than deleted.

## Testing

125 checks, up from 90. The new ones cover upkeep scaling with distinct senses rather than gene count, starvation freeing its cell, population growth and collapse against the replacement rate, extinction being final, the zone floor, crossover drawing from both parents without inventing genes, a lone survivor ending a sexual run but not an asexual one, monogamous pairing, lineage inheritance, and the expression view surviving an empty population.
